### PR TITLE
Component name output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+* Add `name` option for `changes --result` flag that outputs affected component names. PR [#12](https://github.com/powerhome/cobra_commander/pull/12)
+
 ## Version 0.2.0 - 2017-09-01
 
 ### Added

--- a/lib/cobra_commander/affected.rb
+++ b/lib/cobra_commander/affected.rb
@@ -12,10 +12,6 @@ module CobraCommander
       run!
     end
 
-    def paths
-      @paths ||= all_affected.map! { |component| component[:path] }
-    end
-
     def names
       @names ||= paths.map! { |path| File.basename(path) }
     end
@@ -53,6 +49,10 @@ module CobraCommander
 
     def all_affected
       (@directly + @transitively).uniq.sort_by { |h| h[:path] }
+    end
+
+    def paths
+      @paths ||= all_affected.map! { |component| component[:path] }
     end
   end
 end

--- a/lib/cobra_commander/affected.rb
+++ b/lib/cobra_commander/affected.rb
@@ -12,10 +12,16 @@ module CobraCommander
       run!
     end
 
-    def needs_testing
-      @needs_testing ||= all_affected.map! do |component|
-        File.join(component[:path], "test.sh")
-      end
+    def paths
+      @paths ||= all_affected.map! { |component| component[:path] }
+    end
+
+    def names
+      @names ||= paths.map! { |path| File.basename(path) }
+    end
+
+    def scripts
+      @paths ||= paths.map! { |path| File.join(path, "test.sh") }
     end
 
   private

--- a/lib/cobra_commander/change.rb
+++ b/lib/cobra_commander/change.rb
@@ -48,11 +48,15 @@ module CobraCommander
     end
 
     def assert_valid_result_choice
-      raise InvalidSelectionError, "--results must be 'test' or 'full'" unless %w[test full].include?(@results)
+      raise InvalidSelectionError, "--results must be 'test', 'full', or 'name'" unless %w[test full name].include?(@results) # rubocop:disable Metrics/LineLength
     end
 
     def selected_full_results?
       @results == "full"
+    end
+
+    def selected_name_results?
+      @results == "name"
     end
 
     def changes_since_last_commit
@@ -75,7 +79,11 @@ module CobraCommander
 
     def tests_to_run
       puts "<<< Test scripts to run >>>" if selected_full_results?
-      @affected.needs_testing.each { |script| puts script }
+      if selected_name_results?
+        @affected.names.each { |component_name| puts component_name }
+      else
+        @affected.scripts.each { |component_script| puts component_script }
+      end
     end
 
     def display(component)

--- a/lib/cobra_commander/cli.rb
+++ b/lib/cobra_commander/cli.rb
@@ -22,7 +22,7 @@ module CobraCommander
     end
 
     desc "changes APP_PATH [--results=RESULTS] [--branch=BRANCH]", "Prints list of changed files"
-    method_option :results, default: "test", aliases: "-r", desc: "Accepts test or full"
+    method_option :results, default: "test", aliases: "-r", desc: "Accepts test, full, or name"
     method_option :branch, default: "master", aliases: "-b", desc: "Specified target to calculate against"
     def changes(app_path)
       Change.new(app_path, @options[:results], @options[:branch]).run!

--- a/spec/cobra_commander/affected_spec.rb
+++ b/spec/cobra_commander/affected_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CobraCommander::Affected do
     end
 
     it "reports no testing needs" do
-      expect(no_changes.needs_testing).to eq []
+      expect(no_changes.scripts).to eq []
     end
   end
 
@@ -52,7 +52,7 @@ RSpec.describe CobraCommander::Affected do
     end
 
     it "correctly reports testing needs" do
-      expect(with_change_to_a.needs_testing).to eq(["#{@root}/components/a/test.sh"])
+      expect(with_change_to_a.scripts).to eq(["#{@root}/components/a/test.sh"])
     end
   end
 
@@ -101,11 +101,11 @@ RSpec.describe CobraCommander::Affected do
     end
 
     it "correctly reports testing needs" do
-      expect(with_change_to_b.needs_testing).to include("#{@root}/components/a/test.sh")
-      expect(with_change_to_b.needs_testing).to include("#{@root}/components/b/test.sh")
-      expect(with_change_to_b.needs_testing).to include("#{@root}/components/c/test.sh")
-      expect(with_change_to_b.needs_testing).to include("#{@root}/components/d/test.sh")
-      expect(with_change_to_b.needs_testing).to include("#{@root}/node_manifest/test.sh")
+      expect(with_change_to_b.scripts).to include("#{@root}/components/a/test.sh")
+      expect(with_change_to_b.scripts).to include("#{@root}/components/b/test.sh")
+      expect(with_change_to_b.scripts).to include("#{@root}/components/c/test.sh")
+      expect(with_change_to_b.scripts).to include("#{@root}/components/d/test.sh")
+      expect(with_change_to_b.scripts).to include("#{@root}/node_manifest/test.sh")
     end
   end
 
@@ -164,14 +164,14 @@ RSpec.describe CobraCommander::Affected do
     end
 
     it "correctly reports testing needs" do
-      expect(with_change_to_f.needs_testing).to include("#{@root}/components/a/test.sh")
-      expect(with_change_to_f.needs_testing).to include("#{@root}/components/b/test.sh")
-      expect(with_change_to_f.needs_testing).to include("#{@root}/components/c/test.sh")
-      expect(with_change_to_f.needs_testing).to include("#{@root}/components/d/test.sh")
-      expect(with_change_to_f.needs_testing).to_not include("#{@root}/components/e/test.sh")
-      expect(with_change_to_f.needs_testing).to include("#{@root}/components/f/test.sh")
-      expect(with_change_to_f.needs_testing).to include("#{@root}/components/g/test.sh")
-      expect(with_change_to_f.needs_testing).to include("#{@root}/node_manifest/test.sh")
+      expect(with_change_to_f.scripts).to include("#{@root}/components/a/test.sh")
+      expect(with_change_to_f.scripts).to include("#{@root}/components/b/test.sh")
+      expect(with_change_to_f.scripts).to include("#{@root}/components/c/test.sh")
+      expect(with_change_to_f.scripts).to include("#{@root}/components/d/test.sh")
+      expect(with_change_to_f.scripts).to_not include("#{@root}/components/e/test.sh")
+      expect(with_change_to_f.scripts).to include("#{@root}/components/f/test.sh")
+      expect(with_change_to_f.scripts).to include("#{@root}/components/g/test.sh")
+      expect(with_change_to_f.scripts).to include("#{@root}/node_manifest/test.sh")
     end
   end
 end

--- a/spec/cobra_commander/affected_spec.rb
+++ b/spec/cobra_commander/affected_spec.rb
@@ -51,8 +51,12 @@ RSpec.describe CobraCommander::Affected do
       expect(with_change_to_a.transitively).to eq []
     end
 
-    it "correctly reports testing needs" do
+    it "correctly reports test scripts" do
       expect(with_change_to_a.scripts).to eq(["#{@root}/components/a/test.sh"])
+    end
+
+    it "correctly reports component names" do
+      expect(with_change_to_a.names).to eq(["a"])
     end
   end
 
@@ -100,12 +104,20 @@ RSpec.describe CobraCommander::Affected do
       )
     end
 
-    it "correctly reports testing needs" do
+    it "correctly reports test scripts" do
       expect(with_change_to_b.scripts).to include("#{@root}/components/a/test.sh")
       expect(with_change_to_b.scripts).to include("#{@root}/components/b/test.sh")
       expect(with_change_to_b.scripts).to include("#{@root}/components/c/test.sh")
       expect(with_change_to_b.scripts).to include("#{@root}/components/d/test.sh")
       expect(with_change_to_b.scripts).to include("#{@root}/node_manifest/test.sh")
+    end
+
+    it "correctly reports component names" do
+      expect(with_change_to_b.names).to include("a")
+      expect(with_change_to_b.names).to include("b")
+      expect(with_change_to_b.names).to include("c")
+      expect(with_change_to_b.names).to include("d")
+      expect(with_change_to_b.names).to include("node_manifest")
     end
   end
 
@@ -163,7 +175,7 @@ RSpec.describe CobraCommander::Affected do
       )
     end
 
-    it "correctly reports testing needs" do
+    it "correctly reports test scripts" do
       expect(with_change_to_f.scripts).to include("#{@root}/components/a/test.sh")
       expect(with_change_to_f.scripts).to include("#{@root}/components/b/test.sh")
       expect(with_change_to_f.scripts).to include("#{@root}/components/c/test.sh")
@@ -172,6 +184,17 @@ RSpec.describe CobraCommander::Affected do
       expect(with_change_to_f.scripts).to include("#{@root}/components/f/test.sh")
       expect(with_change_to_f.scripts).to include("#{@root}/components/g/test.sh")
       expect(with_change_to_f.scripts).to include("#{@root}/node_manifest/test.sh")
+    end
+
+    it "correctly reports component names" do
+      expect(with_change_to_f.names).to include("a")
+      expect(with_change_to_f.names).to include("b")
+      expect(with_change_to_f.names).to include("c")
+      expect(with_change_to_f.names).to include("d")
+      expect(with_change_to_f.names).to_not include("e")
+      expect(with_change_to_f.names).to include("f")
+      expect(with_change_to_f.names).to include("g")
+      expect(with_change_to_f.names).to include("node_manifest")
     end
   end
 end

--- a/spec/cobra_commander/cli_spec.rb
+++ b/spec/cobra_commander/cli_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "cli", type: :aruba do
       it "outputs error message" do
         run_simple("cobra changes #{@root} -r partial", fail_on_error: true)
 
-        expect(last_command_started).to have_output "--results must be 'test' or 'full'"
+        expect(last_command_started).to have_output "--results must be 'test', 'full', or 'name'"
       end
     end
 


### PR DESCRIPTION
Adds a `name` option for the `changes --results` command.  This outputs the component names and not the full test paths.