### PR TITLE
Add breaking scenario as devDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Add `name` option for `changes --result` flag that outputs affected component names. PR [#12](https://github.com/powerhome/cobra_commander/pull/12)
 
+* Track package.json `devDependencies` in addition to `dependencies`. PR [#13](https://github.com/powerhome/cobra_commander/pull/13)
+
 ## Version 0.2.0 - 2017-09-01
 
 ### Added

--- a/lib/cobra_commander/affected.rb
+++ b/lib/cobra_commander/affected.rb
@@ -13,11 +13,11 @@ module CobraCommander
     end
 
     def names
-      @names ||= paths.map! { |path| File.basename(path) }
+      @names ||= paths.map { |path| File.basename(path) }
     end
 
     def scripts
-      @paths ||= paths.map! { |path| File.join(path, "test.sh") }
+      @paths ||= paths.map { |path| File.join(path, "test.sh") }
     end
 
   private
@@ -52,7 +52,7 @@ module CobraCommander
     end
 
     def paths
-      @paths ||= all_affected.map! { |component| component[:path] }
+      @paths ||= all_affected.map { |component| component[:path] }
     end
   end
 end

--- a/lib/cobra_commander/component_tree.rb
+++ b/lib/cobra_commander/component_tree.rb
@@ -105,7 +105,7 @@ module CobraCommander
           @deps ||= begin
             return [] unless node?
             json = JSON.parse(File.read(package_json_path))
-            format all_deps(json)
+            format combined_deps(json)
           end
         end
 
@@ -127,7 +127,7 @@ module CobraCommander
           File.join(@root_path, "package.json")
         end
 
-        def all_deps(json)
+        def combined_deps(json)
           Hash(json["dependencies"]).merge(Hash(json["devDependencies"]))
         end
       end

--- a/lib/cobra_commander/component_tree.rb
+++ b/lib/cobra_commander/component_tree.rb
@@ -105,7 +105,7 @@ module CobraCommander
           @deps ||= begin
             return [] unless node?
             json = JSON.parse(File.read(package_json_path))
-            format(json["dependencies"])
+            format all_deps(json)
           end
         end
 
@@ -125,6 +125,10 @@ module CobraCommander
 
         def package_json_path
           File.join(@root_path, "package.json")
+        end
+
+        def all_deps(json)
+          Hash(json["dependencies"]).merge(Hash(json["devDependencies"]))
         end
       end
     end

--- a/spec/fixtures/app/node_manifest/package.json
+++ b/spec/fixtures/app/node_manifest/package.json
@@ -7,7 +7,9 @@
   "dependencies": {
     "b": "link:../components/b",
     "e": "link:../components/e",
-    "f": "link:../components/f",
     "g": "link:../components/g"
+  },
+  "devDependencies": {
+    "f": "link:../components/f"
   }
 }


### PR DESCRIPTION
Scraping the `package.json` currently only looks at `"dependencies"`.  This PR adds `"devDependencies"`.