### PR TITLE
Using 'path?' vs removed 'is_a_path?' in bundler

### DIFF
--- a/lib/cobra_commander/component_tree.rb
+++ b/lib/cobra_commander/component_tree.rb
@@ -65,7 +65,7 @@ module CobraCommander
           @deps ||= begin
             return [] unless gem?
             gems = bundler_definition.dependencies.select do |dep|
-              dep.source&.is_a_path? && dep.source.path.to_s != "."
+              dep.source&.path? && dep.source.path.to_s != "."
             end
             format(gems)
           end


### PR DESCRIPTION
Ran into this; I'm not sure how this will impact legacy versions of bundler, maybe we need to put some more intense checks in place?