### PR TITLE
Update setting Bundler to frozen with #set_local

### DIFF
--- a/spec/cobra_commander/component_tree_spec.rb
+++ b/spec/cobra_commander/component_tree_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe CobraCommander::ComponentTree do
       # (triggered by `gemspec` in its Gemfile) as a Bundler::Source::Path, rather than a
       # Bundler::Source::Gemspec. This can be confused with a dependency on another component.
       before do
-        @original = Bundler.settings[:frozen]
-        Bundler.settings[:frozen] = true
+        @original = Bundler.settings.frozen?
+        Bundler.settings.set_local(:frozen, true)
       end
 
       it "#component_dependencies still accurately selects" do
@@ -28,7 +28,7 @@ RSpec.describe CobraCommander::ComponentTree do
       end
 
       after do
-        Bundler.settings[:frozen] = @original
+        Bundler.settings.set_local(:frozen, @original)
       end
     end
   end


### PR DESCRIPTION
Resolves 

```ruby
undefined method '[]=' for #<Bundler::Settings:0x00007f96ad0a81b0> with alias method
```

This occurs locally and in CI.