### PR TITLE
Add command to count component dependencies

### DIFF
--- a/lib/cobra_commander/cli.rb
+++ b/lib/cobra_commander/cli.rb
@@ -10,6 +10,13 @@ module CobraCommander
       puts FormattedOutput.new(app_path).run!
     end
 
+    desc "count_dependencies APP_PATH", "Outputs count of components in APP_PATH dependent on COMPONENT"
+    method_option :component, required: true, aliases: "-c", desc: "Name of component: core_models or nitro_component_transition"
+    method_option :format, default: "count", aliases: "-f", desc: "count or list"
+    def count_dependencies(app_path)
+      puts FormattedOutput.new(app_path).count_dependencies!(@options[:component], @options[:format])
+    end
+
     desc "version", "Prints version"
     def version
       puts CobraCommander::VERSION

--- a/lib/cobra_commander/formatted_output.rb
+++ b/lib/cobra_commander/formatted_output.rb
@@ -22,7 +22,28 @@ module CobraCommander
       nil
     end
 
+    def count_dependencies!(component_name, format)
+      @component_name = component_name
+
+      results = @tree[:dependencies].map do |component|
+        if @component_name == component[:name]
+          @tree[:name]
+        elsif dependency?(component)
+          component[:name]
+        end
+      end.compact
+
+      "list" == format ? results : results.size
+    end
+
   private
+
+    def dependency?(deps)
+      deps[:dependencies].each do |dep|
+        return true if @component_name == dep[:name] || dependency?(dep)
+      end
+      false
+    end
 
     def list_dependencies(deps, outdents = [])
       deps[:dependencies].each do |dep|

--- a/spec/cobra_commander/cli_spec.rb
+++ b/spec/cobra_commander/cli_spec.rb
@@ -143,4 +143,30 @@ RSpec.describe "cli", type: :aruba do
       end
     end
   end
+
+  describe "counting dependencies on a component in the tree" do
+    it "counts a component's direct dependency" do
+      run_simple("cobra count_dependencies #{@root} --component=node_manifest --format=list", fail_on_error: true)
+
+      expect(last_command_started.output.strip.split("\n")).to match(["App"])
+    end
+
+    it "counts a component's transient dependency" do
+      run_simple("cobra count_dependencies #{@root} --component=g --format=list", fail_on_error: true)
+
+      expect(last_command_started.output.strip.split("\n")).to match(%w[a d node_manifest])
+    end
+
+    it "counts a component's transient dependency" do
+      run_simple("cobra count_dependencies #{@root} --component=g --format=count", fail_on_error: true)
+
+      expect(last_command_started.output.to_i).to eq(3)
+    end
+
+    it "doesn't count a component it's not dependent on" do
+      run_simple("cobra count_dependencies #{@root} --component=non_existent --format=list", fail_on_error: true)
+
+      expect(last_command_started.output.strip.split("\n")).to match([])
+    end
+  end
 end


### PR DESCRIPTION
We can now count components that have a direct or transient dependency upon another component.

```bash
$ cobra count_dependencies ~/code/nitro -c core_models
23

$ cobra count_dependencies ~/code/nitro -c core_models -f list
adp
allowances
call_queues
call_transcriptions
charitable_giving
client
contact_center
App # note: this represents a direct dependency on core_models
mdm
mobile_devices
nitro_component_transition
nitro_graphql
outbound_marketing
power_glossary
powerlife
recruiting
solar_roofing
spaces
sso
support
support_ticket_model
travel
utu_observer
```