### PR TITLE
Introduce `cobra do`

### DIFF
--- a/lib/cobra_commander.rb
+++ b/lib/cobra_commander.rb
@@ -7,6 +7,7 @@ require "cobra_commander/graph"
 require "cobra_commander/change"
 require "cobra_commander/affected"
 require "cobra_commander/output"
+require "cobra_commander/executor"
 
 # Tools for working with Component Based Rails Apps (see http://shageman.github.io/cbra.info/).
 # Includes tools for graphing the components of an app and their relationships, as well as selectively

--- a/lib/cobra_commander/cli.rb
+++ b/lib/cobra_commander/cli.rb
@@ -5,6 +5,14 @@ require "thor"
 module CobraCommander
   # Implements the tool's CLI
   class CLI < Thor
+    desc "do [command]", "Executes the command in the context of each component in [app]"
+    method_option :app, default: Dir.pwd, aliases: "-a", desc: "App path (default: CWD)"
+    def do(command)
+      tree = CobraCommander.umbrella_tree(options.app)
+      executor = Executor.new(tree)
+      executor.exec(command)
+    end
+
     desc "ls [app_path]", "Prints tree of components for an app"
     method_option :app, default: Dir.pwd, aliases: "-a", desc: "App path (default: CWD)"
     method_option :format, default: "tree", aliases: "-f", desc: "Format (list or tree, default: list)"

--- a/lib/cobra_commander/component_tree.rb
+++ b/lib/cobra_commander/component_tree.rb
@@ -17,6 +17,10 @@ module CobraCommander
       @type = type_of_component
     end
 
+    def flatten
+      _flatten(self)
+    end
+
     def subtree(name)
       _subtree(name, self)
     end
@@ -54,6 +58,12 @@ module CobraCommander
     end
 
   private
+
+    def _flatten(component)
+      component.dependencies.map do |dep|
+        [dep] + _flatten(dep)
+      end.flatten.uniq(&:name)
+    end
 
     def _subtree(name, tree)
       return tree if tree.name == name

--- a/lib/cobra_commander/component_tree.rb
+++ b/lib/cobra_commander/component_tree.rb
@@ -25,14 +25,14 @@ module CobraCommander
       _subtree(name, self)
     end
 
-    def depends_directly?(component_name)
+    def depends_on?(component_name)
       dependencies.any? do |component|
-        component.name == component_name || component.depends_directly?(component_name)
+        component.name == component_name || component.depends_on?(component_name)
       end
     end
 
     def dependents_of(component_name)
-      depends = depends_directly?(component_name) ? self : nil
+      depends = depends_on?(component_name) ? self : nil
       dependents_below = dependencies.map do |component|
         component.dependents_of(component_name)
       end

--- a/lib/cobra_commander/component_tree.rb
+++ b/lib/cobra_commander/component_tree.rb
@@ -6,11 +6,11 @@ require "json"
 module CobraCommander
   # Represents a dependency tree in a given context
   class ComponentTree
-    attr_reader :name
+    attr_reader :name, :path
 
     def initialize(name, path, ancestry = Set.new)
       @name = name
-      @root_path = path
+      @path = path
       @ancestry = ancestry
       @ruby = Ruby.new(path)
       @js = Js.new(path)
@@ -42,7 +42,7 @@ module CobraCommander
     def to_h
       {
         name: @name,
-        path: @root_path,
+        path: path,
         type: @type,
         ancestry: @ancestry,
         dependencies: dependencies.map(&:to_h),
@@ -79,8 +79,8 @@ module CobraCommander
     end
 
     def dep_representation(dep)
-      full_path = File.expand_path(File.join(@root_path, dep[:path]))
-      ancestry = @ancestry + [{ name: @name, path: @root_path, type: @type }]
+      full_path = File.expand_path(File.join(path, dep[:path]))
+      ancestry = @ancestry + [{ name: @name, path: path, type: @type }]
       ComponentTree.new(dep[:name], full_path, ancestry)
     end
 

--- a/lib/cobra_commander/executor.rb
+++ b/lib/cobra_commander/executor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module CobraCommander
+  # Execute commands on all components of a ComponentTree
   class Executor
     def initialize(tree)
       @tree = tree
@@ -9,11 +10,11 @@ module CobraCommander
     def exec(command, printer = $stdout)
       @tree.flatten.each do |component|
         printer.puts "===> #{component.name} (#{component.path})"
-        output, _ = run_in_component(component, command)
+        output, = run_in_component(component, command)
         printer.puts output
       end
     end
-  
+
   private
 
     def run_in_component(component, command)
@@ -23,7 +24,7 @@ module CobraCommander
     end
 
     def env_vars(component)
-      {"CURRENT_COMPONENT" => component.name, "CURRENT_COMPONENT_PATH" => component.path}
+      { "CURRENT_COMPONENT" => component.name, "CURRENT_COMPONENT_PATH" => component.path }
     end
   end
 end

--- a/lib/cobra_commander/executor.rb
+++ b/lib/cobra_commander/executor.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CobraCommander
+  class Executor
+    def initialize(tree)
+      @tree = tree
+    end
+
+    def exec(command, printer = $stdout)
+      @tree.flatten.each do |component|
+        printer.puts "===> #{component.name} (#{component.path})"
+        output, _ = run_in_component(component, command)
+        printer.puts output
+      end
+    end
+  
+  private
+
+    def run_in_component(component, command)
+      Dir.chdir(component.path) do
+        Open3.capture2e(env_vars(component), command)
+      end
+    end
+
+    def env_vars(component)
+      {"CURRENT_COMPONENT" => component.name, "CURRENT_COMPONENT_PATH" => component.path}
+    end
+  end
+end

--- a/lib/cobra_commander/output.rb
+++ b/lib/cobra_commander/output.rb
@@ -15,15 +15,7 @@ module CobraCommander
       end
 
       def to_s
-        flatten_tree(@tree)
-      end
-
-    private
-
-      def flatten_tree(component)
-        component.dependencies.map do |dep|
-          [dep.name] + flatten_tree(dep)
-        end.flatten.uniq
+        @tree.flatten.map(&:name)
       end
     end
 

--- a/spec/cobra_commander/executor_spec.rb
+++ b/spec/cobra_commander/executor_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CobraCommander::Executor do
+  let(:tree) { CobraCommander.umbrella_tree(AppHelper.root) }
+  subject { CobraCommander::Executor.new(tree) }
+
+  it "executes the given command once on each element of the tree" do
+    output = StringIO.new
+    subject.exec("pwd", output)
+
+    expect(output.string).to match %r{===> a \(.*spec/fixtures/app/components/a\)
+.*spec/fixtures/app/components/a
+===> b \(.*spec/fixtures/app/components/b\)
+.*spec/fixtures/app/components/b
+===> g \(.*spec/fixtures/app/components/g\)
+.*spec/fixtures/app/components/g
+===> e \(.*spec/fixtures/app/components/e\)
+.*spec/fixtures/app/components/e
+===> f \(.*spec/fixtures/app/components/f\)
+.*spec/fixtures/app/components/f
+===> c \(.*spec/fixtures/app/components/c\)
+.*spec/fixtures/app/components/c
+===> d \(.*spec/fixtures/app/components/d\)
+.*spec/fixtures/app/components/d
+===> node_manifest \(.*spec/fixtures/app/node_manifest\)
+.*spec/fixtures/app/node_manifest}
+  end
+
+  it "exposes CURRENT_COMPONENT and CURRENT_COMPONENT_PATH environment variables" do
+    output = StringIO.new
+    subject.exec("echo $CURRENT_COMPONENT $CURRENT_COMPONENT_PATH", output)
+
+    expect(output.string).to match %r{===> a \(.*spec/fixtures/app/components/a\)
+a .*spec/fixtures/app/components/a
+===> b \(.*spec/fixtures/app/components/b\)
+b .*spec/fixtures/app/components/b
+===> g \(.*spec/fixtures/app/components/g\)
+g .*spec/fixtures/app/components/g
+===> e \(.*spec/fixtures/app/components/e\)
+e .*spec/fixtures/app/components/e
+===> f \(.*spec/fixtures/app/components/f\)
+f .*spec/fixtures/app/components/f
+===> c \(.*spec/fixtures/app/components/c\)
+c .*spec/fixtures/app/components/c
+===> d \(.*spec/fixtures/app/components/d\)
+d .*spec/fixtures/app/components/d
+===> node_manifest \(.*spec/fixtures/app/node_manifest\)
+node_manifest .*spec/fixtures/app/node_manifest}
+  end
+end


### PR DESCRIPTION
Introduce `cobra do` to run commands within a component context

```
$ cobra do 'echo hello from $CURRENT_COMPONENT' -a spec/fixtures/app
===> a (/Users/chjunior/cobra_commander/spec/fixtures/app/components/a)
hello from a
===> b (/Users/chjunior/cobra_commander/spec/fixtures/app/components/b)
hello from b
===> g (/Users/chjunior/cobra_commander/spec/fixtures/app/components/g)
hello from g
===> e (/Users/chjunior/cobra_commander/spec/fixtures/app/components/e)
hello from e
===> f (/Users/chjunior/cobra_commander/spec/fixtures/app/components/f)
hello from f
===> c (/Users/chjunior/cobra_commander/spec/fixtures/app/components/c)
hello from c
===> d (/Users/chjunior/cobra_commander/spec/fixtures/app/components/d)
hello from d
===> node_manifest (/Users/chjunior/cobra_commander/spec/fixtures/app/node_manifest)
hello from node_manifest
```