### PR TITLE
Adds instructions to install graphviz

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Commands:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. You will also need to install `graphviz` by running `brew install graphviz`. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
While doing the setup of the code I realized some tests were failing due to have graphviz missing in my local environment. This PR is to add this instruction to the documentation so you can have everything properly setup before you can run the tests.