### PR TITLE
Allow caching component tree for faster output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Tracks package.json `workspaces` in addition to `dependencies` and `devDependencies`. PR [#31](https://github.com/powerhome/cobra_commander/pull/31)
+* Permits caching the component tree of a project on disk to avoid calculating it repeatedly on subsequent cobra invocations.
 
 ## Version 0.5.1 - 2018-10-15
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ Or install it yourself as:
 
 ```bash
 Commands:
-  cobra changes APP_PATH [--results=RESULTS] [--branch=BRANCH]                # Prints list of changed files
-  cobra graph APP_PATH [--format=FORMAT]                                      # Outputs graph
-  cobra help [COMMAND]                                                        # Describe available commands or one specific command
-  cobra ls APP_PATH  [--format=list|tree]                                     # Prints tree of components for an app
-  cobra version                                                               # Prints version
-  cobra do [command]                                                          # Executes the command in the context of each component
-  cobra dependencies_of [component] [--app=/path/to/app] [--format=list|tree] # Lists the dependencies of the component in the app context
-  cobra dependents_of [component] [--app=/path/to/app] [--format=list|count]  # Lists or counts the components that depend directly or indirectly on the given component
-  cobra version                                                               # Prints version
+  cobra cache APP_PATH CACHE_PATH                                                # Caches a representation of the component structure of the app
+  cobra changes APP_PATH [--results=RESULTS] [--branch=BRANCH] [--cache=nil]     # Prints list of changed files
+  cobra dependencies_of [component] [--app=pwd] [--format=FORMAT] [--cache=nil]  # Outputs a list of components that [component] depends on within [app] context
+  cobra dependents_of [component] [--app=pwd] [--format=FORMAT] [--cache=nil]    # Outputs count of components in [app] dependent on [component]
+  cobra do [command] [--app=pwd] [--cache=nil]                                   # Executes the command in the context of each component in [app]
+  cobra graph APP_PATH [--format=FORMAT] [--cache=nil]                           # Outputs graph
+  cobra help [COMMAND]                                                           # Describe available commands or one specific command
+  cobra ls [app_path] [--app=pwd] [--format=FORMAT] [--cache=nil]                # Prints tree of components for an app
+  cobra version                                                                  # Prints version
 ```
 
 ## Development

--- a/lib/cobra_commander.rb
+++ b/lib/cobra_commander.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "cobra_commander/cli"
-require "cobra_commander/component_tree"
+require "cobra_commander/cached_component_tree"
+require "cobra_commander/calculated_component_tree"
 require "cobra_commander/version"
 require "cobra_commander/graph"
 require "cobra_commander/change"
@@ -16,6 +17,10 @@ module CobraCommander
   UMBRELLA_APP_NAME = "App"
 
   def self.umbrella_tree(path)
-    ComponentTree.new(UMBRELLA_APP_NAME, path)
+    CalculatedComponentTree.new(UMBRELLA_APP_NAME, path)
+  end
+
+  def self.tree_from_cache(cache_file)
+    CachedComponentTree.from_cache_file(cache_file)
   end
 end

--- a/lib/cobra_commander/cached_component_tree.rb
+++ b/lib/cobra_commander/cached_component_tree.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "cobra_commander/component_tree"
+
+module CobraCommander
+  # Represents a dependency tree in a given context, built from a cache
+  class CachedComponentTree < ComponentTree
+    attr_reader :dependencies
+
+    def self.from_cache_file(cache_file)
+      cache = JSON.parse(File.read(cache_file), symbolize_names: true)
+      new(cache)
+    end
+
+    def initialize(cache)
+      super(cache[:name], cache[:path])
+      @type = cache[:type]
+      @ancestry = Set.new(cache[:ancestry])
+      @dependencies = (cache[:dependencies] || []).map do |dep|
+        CachedComponentTree.new(dep)
+      end
+    end
+  end
+end

--- a/lib/cobra_commander/calculated_component_tree.rb
+++ b/lib/cobra_commander/calculated_component_tree.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "cobra_commander/component_tree"
+
+module CobraCommander
+  # Represents a dependency tree in a given context
+  class CalculatedComponentTree < ComponentTree
+    attr_reader :name, :path
+
+    def initialize(name, path, ancestry = Set.new)
+      super(name, path)
+      @ancestry = ancestry
+      @ruby = Ruby.new(path)
+      @js = Js.new(path)
+      @type = type_of_component
+    end
+
+    def dependencies
+      @deps ||= begin
+        deps = @ruby.dependencies + @js.dependencies
+        deps.sort_by { |dep| dep[:name] }
+            .map(&method(:dep_representation))
+      end
+    end
+
+  private
+
+    def type_of_component
+      return "Ruby & JS" if @ruby.gem? && @js.node?
+      return "Ruby" if @ruby.gem?
+      return "JS" if @js.node?
+    end
+
+    def dep_representation(dep)
+      full_path = File.expand_path(File.join(path, dep[:path]))
+      ancestry = @ancestry + [{ name: @name, path: path, type: @type }]
+      CalculatedComponentTree.new(dep[:name], full_path, ancestry)
+    end
+
+    # Calculates ruby dependencies
+    class Ruby
+      def initialize(root_path)
+        @root_path = root_path
+      end
+
+      def dependencies
+        @deps ||= begin
+          return [] unless gem?
+          gems = bundler_definition.dependencies.select { |dep| path?(dep.source) }
+          format(gems)
+        end
+      end
+
+      def path?(source)
+        return if source.nil?
+        source_has_path = source.respond_to?(:path?) ? source.path? : source.is_a_path?
+        source_has_path && source.path.to_s != "."
+      end
+
+      def format(deps)
+        deps.map do |dep|
+          path = File.join(dep.source.path, dep.name)
+          { name: dep.name, path: path }
+        end
+      end
+
+      def gem?
+        @gem ||= File.exist?(gemfile_path)
+      end
+
+      def bundler_definition
+        ::Bundler::Definition.build(gemfile_path, gemfile_lock_path, nil)
+      end
+
+      def gemfile_path
+        File.join(@root_path, "Gemfile")
+      end
+
+      def gemfile_lock_path
+        File.join(@root_path, "Gemfile.lock")
+      end
+    end
+
+    # Calculates js dependencies
+    class Js
+      def initialize(root_path)
+        @root_path = root_path
+      end
+
+      def dependencies
+        @deps ||= begin
+          return [] unless node?
+          json = JSON.parse(File.read(package_json_path))
+          combined_deps(json)
+        end
+      end
+
+      def format_dependencies(deps)
+        return [] if deps.nil?
+        linked_deps = deps.select { |_, v| v.start_with? "link:" }
+        linked_deps.map do |_, v|
+          relational_path = v.split("link:")[1]
+          dep_name = relational_path.split("/")[-1]
+          { name: dep_name, path: relational_path }
+        end
+      end
+
+      def node?
+        @node ||= File.exist?(package_json_path)
+      end
+
+      def package_json_path
+        File.join(@root_path, "package.json")
+      end
+
+      def combined_deps(json)
+        worskpace_dependencies = build_workspaces(json["workspaces"])
+        dependencies = format_dependencies Hash(json["dependencies"]).merge(Hash(json["devDependencies"]))
+        (dependencies + worskpace_dependencies).uniq
+      end
+
+      def build_workspaces(workspaces)
+        return [] if workspaces.nil?
+        workspaces.map do |workspace|
+          glob = "#{@root_path}/#{workspace}/package.json"
+          workspace_dependencies = Dir.glob(glob)
+          workspace_dependencies.map do |wd|
+            { name: component_name(wd), path: component_path(wd) }
+          end
+        end.flatten
+      end
+
+    private
+
+      def component_name(dir)
+        component_path(dir).split("/")[-1]
+      end
+
+      def component_path(dir)
+        return dir.split("/package.json")[0] if @root_path == "."
+
+        dir.split(@root_path)[-1].split("/package.json")[0]
+      end
+    end
+  end
+end

--- a/lib/cobra_commander/change.rb
+++ b/lib/cobra_commander/change.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "cobra_commander/component_tree"
 require "cobra_commander/affected"
 require "open3"
 
@@ -9,12 +8,12 @@ module CobraCommander
   class Change
     InvalidSelectionError = Class.new(StandardError)
 
-    def initialize(path, results, branch)
-      @root_dir = Dir.chdir(path) { `git rev-parse --show-toplevel`.chomp }
+    def initialize(tree, results, branch)
+      @root_dir = Dir.chdir(tree.path) { `git rev-parse --show-toplevel`.chomp }
       @results = results
       @branch = branch
-      @tree = CobraCommander.umbrella_tree(path).to_h
-      @affected = Affected.new(@tree, changes, path)
+      @tree = tree.to_h
+      @affected = Affected.new(@tree, changes, tree.path)
     end
 
     def run!

--- a/lib/cobra_commander/cli.rb
+++ b/lib/cobra_commander/cli.rb
@@ -1,42 +1,55 @@
 # frozen_string_literal: true
 
 require "thor"
+require "fileutils"
 
 module CobraCommander
   # Implements the tool's CLI
   class CLI < Thor
-    desc "do [command]", "Executes the command in the context of each component in [app]"
+    CACHE_DESCRIPTION = "Path to a cache file to use (default: nil). If specified, this file will be used to store " \
+      "the component tree for the app to speed up subsequent invocations. Must be rotated any time the component " \
+      "dependency structure changes."
+    COMMON_OPTIONS = "[--app=pwd] [--format=FORMAT] [--cache=nil]"
+
+    desc "do [command] [--app=pwd] [--cache=nil]", "Executes the command in the context of each component in [app]"
     method_option :app, default: Dir.pwd, aliases: "-a", desc: "App path (default: CWD)"
+    method_option :cache, default: nil, aliases: "-c", desc: CACHE_DESCRIPTION
     def do(command)
-      tree = CobraCommander.umbrella_tree(options.app)
+      tree = maybe_cached_tree(options.app, options.cache)
       executor = Executor.new(tree)
       executor.exec(command)
     end
 
-    desc "ls [app_path]", "Prints tree of components for an app"
+    desc "ls [app_path] #{COMMON_OPTIONS}", "Prints tree of components for an app"
     method_option :app, default: Dir.pwd, aliases: "-a", desc: "App path (default: CWD)"
     method_option :format, default: "tree", aliases: "-f", desc: "Format (list or tree, default: list)"
+    method_option :cache, default: nil, aliases: "-c", desc: CACHE_DESCRIPTION
     def ls(app_path = nil)
+      tree = maybe_cached_tree(app_path || options.app, options.cache)
       Output.print(
-        CobraCommander.umbrella_tree(app_path || options.app),
+        tree,
         options.format
       )
     end
 
-    desc "dependents_of [component]", "Outputs count of components in [app] dependent on [component]"
+    desc "dependents_of [component] #{COMMON_OPTIONS}", "Outputs count of components in [app] dependent on [component]"
     method_option :app, default: Dir.pwd, aliases: "-a", desc: "Path to the root app where the component is mounted"
     method_option :format, default: "count", aliases: "-f", desc: "count or list"
+    method_option :cache, default: nil, aliases: "-c", desc: CACHE_DESCRIPTION
     def dependents_of(component)
-      dependents = CobraCommander.umbrella_tree(options.app).dependents_of(component)
+      tree = maybe_cached_tree(options.app, options.cache)
+      dependents = tree.dependents_of(component)
       puts "list" == options.format ? dependents.map(&:name) : dependents.size
     end
 
-    desc "dependencies_of [component]", "Outputs a list of components that [component] depends on within [app] context"
+    desc "dependencies_of [component] #{COMMON_OPTIONS}", "Outputs a list of components that [component] depends on"
     method_option :app, default: Dir.pwd, aliases: "-a", desc: "App path (default: CWD)"
     method_option :format, default: "list", aliases: "-f", desc: "Format (list or tree, default: list)"
+    method_option :cache, default: nil, aliases: "-c", desc: CACHE_DESCRIPTION
     def dependencies_of(component)
+      tree = maybe_cached_tree(options.app, options.cache)
       Output.print(
-        CobraCommander.umbrella_tree(options.app).subtree(component),
+        tree.subtree(component),
         options.format
       )
     end
@@ -46,17 +59,47 @@ module CobraCommander
       puts CobraCommander::VERSION
     end
 
-    desc "graph APP_PATH [--format=FORMAT]", "Outputs graph"
+    desc "graph APP_PATH [--format=FORMAT] [--cache=nil]", "Outputs graph"
     method_option :format, default: "png", aliases: "-f", desc: "Accepts png or dot"
+    method_option :cache, default: nil, aliases: "-c", desc: CACHE_DESCRIPTION
     def graph(app_path)
-      Graph.new(app_path, options.format).generate!
+      tree = maybe_cached_tree(app_path, options.cache)
+      Graph.new(tree, options.format).generate!
     end
 
-    desc "changes APP_PATH [--results=RESULTS] [--branch=BRANCH]", "Prints list of changed files"
+    desc "changes APP_PATH [--results=RESULTS] [--branch=BRANCH] [--cache=nil]", "Prints list of changed files"
     method_option :results, default: "test", aliases: "-r", desc: "Accepts test, full, name or json"
     method_option :branch, default: "master", aliases: "-b", desc: "Specified target to calculate against"
+    method_option :cache, default: nil, aliases: "-c", desc: CACHE_DESCRIPTION
     def changes(app_path)
-      Change.new(app_path, options.results, options.branch).run!
+      tree = maybe_cached_tree(app_path, options.cache)
+      Change.new(tree, options.results, options.branch).run!
+    end
+
+    desc "cache APP_PATH CACHE_PATH", "Caches a representation of the component structure of the app"
+    def cache(app_path, cache_path)
+      tree = CobraCommander.umbrella_tree(app_path)
+      write_tree_cache(tree, cache_path)
+      puts "Created cache of component tree at #{cache_path}"
+    end
+
+  private
+
+    def maybe_cached_tree(app_path, cache_path)
+      return CobraCommander.umbrella_tree(app_path) unless cache_path
+
+      if File.exist?(cache_path)
+        CobraCommander.tree_from_cache(cache_path)
+      else
+        tree = CobraCommander.umbrella_tree(app_path)
+        write_tree_cache(tree, cache_path)
+        tree
+      end
+    end
+
+    def write_tree_cache(tree, cache_path)
+      FileUtils.mkdir_p(File.dirname(cache_path))
+      File.write(cache_path, tree.to_json)
     end
   end
 end

--- a/lib/cobra_commander/component_tree.rb
+++ b/lib/cobra_commander/component_tree.rb
@@ -8,13 +8,9 @@ module CobraCommander
   class ComponentTree
     attr_reader :name, :path
 
-    def initialize(name, path, ancestry = Set.new)
+    def initialize(name, path)
       @name = name
       @path = path
-      @ancestry = ancestry
-      @ruby = Ruby.new(path)
-      @js = Js.new(path)
-      @type = type_of_component
     end
 
     def flatten
@@ -39,22 +35,18 @@ module CobraCommander
       [depends, dependents_below].flatten.compact.uniq(&:name)
     end
 
-    def to_h
+    def to_h(json_compatible: false)
       {
         name: @name,
         path: path,
         type: @type,
-        ancestry: @ancestry,
-        dependencies: dependencies.map(&:to_h),
+        ancestry: json_compatible ? @ancestry.to_a : @ancestry,
+        dependencies: dependencies.map { |dep| dep.to_h(json_compatible: json_compatible) },
       }
     end
 
-    def dependencies
-      @deps ||= begin
-        deps = @ruby.dependencies + @js.dependencies
-        deps.sort_by { |dep| dep[:name] }
-            .map(&method(:dep_representation))
-      end
+    def to_json
+      JSON.dump(to_h(json_compatible: true))
     end
 
   private
@@ -72,124 +64,6 @@ module CobraCommander
         return presence if presence
       end
       nil
-    end
-
-    def type_of_component
-      return "Ruby & JS" if @ruby.gem? && @js.node?
-      return "Ruby" if @ruby.gem?
-      return "JS" if @js.node?
-    end
-
-    def dep_representation(dep)
-      full_path = File.expand_path(File.join(path, dep[:path]))
-      ancestry = @ancestry + [{ name: @name, path: path, type: @type }]
-      ComponentTree.new(dep[:name], full_path, ancestry)
-    end
-
-    # Calculates ruby dependencies
-    class Ruby
-      def initialize(root_path)
-        @root_path = root_path
-      end
-
-      def dependencies
-        @deps ||= begin
-          return [] unless gem?
-          gems = bundler_definition.dependencies.select { |dep| path?(dep.source) }
-          format(gems)
-        end
-      end
-
-      def path?(source)
-        return if source.nil?
-        source_has_path = source.respond_to?(:path?) ? source.path? : source.is_a_path?
-        source_has_path && source.path.to_s != "."
-      end
-
-      def format(deps)
-        deps.map do |dep|
-          path = File.join(dep.source.path, dep.name)
-          { name: dep.name, path: path }
-        end
-      end
-
-      def gem?
-        @gem ||= File.exist?(gemfile_path)
-      end
-
-      def bundler_definition
-        ::Bundler::Definition.build(gemfile_path, gemfile_lock_path, nil)
-      end
-
-      def gemfile_path
-        File.join(@root_path, "Gemfile")
-      end
-
-      def gemfile_lock_path
-        File.join(@root_path, "Gemfile.lock")
-      end
-    end
-
-    # Calculates js dependencies
-    class Js
-      def initialize(root_path)
-        @root_path = root_path
-      end
-
-      def dependencies
-        @deps ||= begin
-          return [] unless node?
-          json = JSON.parse(File.read(package_json_path))
-          combined_deps(json)
-        end
-      end
-
-      def format_dependencies(deps)
-        return [] if deps.nil?
-        linked_deps = deps.select { |_, v| v.start_with? "link:" }
-        linked_deps.map do |_, v|
-          relational_path = v.split("link:")[1]
-          dep_name = relational_path.split("/")[-1]
-          { name: dep_name, path: relational_path }
-        end
-      end
-
-      def node?
-        @node ||= File.exist?(package_json_path)
-      end
-
-      def package_json_path
-        File.join(@root_path, "package.json")
-      end
-
-      def combined_deps(json)
-        worskpace_dependencies = build_workspaces(json["workspaces"])
-        dependencies = format_dependencies Hash(json["dependencies"]).merge(Hash(json["devDependencies"]))
-        (dependencies + worskpace_dependencies).uniq
-      end
-
-      def build_workspaces(workspaces)
-        return [] if workspaces.nil?
-        workspaces.map do |workspace|
-          glob = "#{@root_path}/#{workspace}/package.json"
-          workspace_dependencies = Dir.glob(glob)
-          workspace_dependencies.map do |wd|
-            { name: component_name(wd), path: component_path(wd) }
-          end
-        end.flatten
-      end
-
-    private
-
-      def component_name(dir)
-        component_path(dir).split("/")[-1]
-      end
-
-      def component_path(dir)
-        return dir.split("/package.json")[0] if @root_path == "."
-
-        dir.split(@root_path)[-1].split("/package.json")[0]
-      end
     end
   end
 end

--- a/lib/cobra_commander/graph.rb
+++ b/lib/cobra_commander/graph.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 require "graphviz"
-require "cobra_commander/component_tree"
 
 module CobraCommander
   # Generates graphs of components
   class Graph
-    def initialize(app_path, format)
+    def initialize(tree, format)
       @format = format
-      @tree = CobraCommander.umbrella_tree(app_path).to_h
+      @tree = tree.to_h
     end
 
     def generate!

--- a/spec/cobra_commander/calculated_component_tree_spec.rb
+++ b/spec/cobra_commander/calculated_component_tree_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe CobraCommander::ComponentTree do
+RSpec.describe CobraCommander::CalculatedComponentTree do
   context "for the fixture app" do
     subject do
       CobraCommander.umbrella_tree(AppHelper.root)

--- a/spec/cobra_commander/change_spec.rb
+++ b/spec/cobra_commander/change_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe CobraCommander::Change do
     @tree = AppHelper.tree
   end
 
-  before do
-    allow_any_instance_of(CobraCommander::ComponentTree).to receive(:to_h).and_return(@tree)
+  let(:tree) do
+    double(to_h: @tree, path: @root)
   end
 
   it "successfully instantiates" do
-    expect(described_class.new(@root, "full", "master")).to be_truthy
+    expect(described_class.new(tree, "full", "master")).to be_truthy
   end
 
   describe ".run!" do
@@ -23,7 +23,7 @@ RSpec.describe CobraCommander::Change do
           allow_any_instance_of(CobraCommander::Change).to receive(:changes).and_return([])
 
           expect do
-            described_class.new(@root, "json", "master").run!
+            described_class.new(tree, "json", "master").run!
           end.to output(<<~OUTPUT
             {"changed_files":[],"directly_affected_components":[],"transitively_affected_components":[],"test_scripts":[],"component_names":[],"languages":{"ruby":false,"javascript":false}}
             OUTPUT
@@ -40,7 +40,7 @@ RSpec.describe CobraCommander::Change do
           )
 
           expect do
-            described_class.new(@root, "json", "master").run!
+            described_class.new(tree, "json", "master").run!
           end.to output(<<~OUTPUT
             {"changed_files":["#{@root}/components/a"],"directly_affected_components":[{"name":"a","path":"#{@root}/components/a","type":"Ruby"}],"transitively_affected_components":[],"test_scripts":["#{@root}/components/a/test.sh"],"component_names":["a"],"languages":{"ruby":true,"javascript":false}}
             OUTPUT
@@ -57,7 +57,7 @@ RSpec.describe CobraCommander::Change do
           )
 
           expect do
-            described_class.new(@root, "json", "master").run!
+            described_class.new(tree, "json", "master").run!
           end.to output(<<~OUTPUT
             {"changed_files":["#{@root}/components/e"],"directly_affected_components":[{"name":"e","path":"#{@root}/components/e","type":"JS"}],"transitively_affected_components":[{"name":"a","path":"#{@root}/components/a","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"c","path":"#{@root}/components/c","type":"Ruby"},{"name":"d","path":"#{@root}/components/d","type":"Ruby"},{"name":"g","path":"#{@root}/components/g","type":"JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"}],"test_scripts":["#{@root}/components/a/test.sh","#{@root}/components/b/test.sh","#{@root}/components/c/test.sh","#{@root}/components/d/test.sh","#{@root}/components/e/test.sh","#{@root}/components/g/test.sh","#{@root}/node_manifest/test.sh"],"component_names":["a","b","c","d","e","g","node_manifest"],"languages":{"ruby":true,"javascript":true}}
             OUTPUT
@@ -72,7 +72,7 @@ RSpec.describe CobraCommander::Change do
           allow_any_instance_of(CobraCommander::Change).to receive(:changes).and_return([])
 
           expect do
-            described_class.new(@root, "full", "master").run!
+            described_class.new(tree, "full", "master").run!
           end.to output(<<~OUTPUT
             <<< Changes since last commit on master >>>
 
@@ -95,7 +95,7 @@ RSpec.describe CobraCommander::Change do
           )
 
           expect do
-            described_class.new(@root, "full", "master").run!
+            described_class.new(tree, "full", "master").run!
           end.to output(<<~OUTPUT
             <<< Changes since last commit on master >>>
             /change
@@ -119,7 +119,7 @@ RSpec.describe CobraCommander::Change do
           )
 
           expect do
-            described_class.new(@root, "full", "master").run!
+            described_class.new(tree, "full", "master").run!
           end.to output(<<~OUTPUT
             <<< Changes since last commit on master >>>
             #{@root}/components/a
@@ -146,7 +146,7 @@ RSpec.describe CobraCommander::Change do
           )
 
           expect do
-            described_class.new(@root, "full", "master").run!
+            described_class.new(tree, "full", "master").run!
           end.to output(<<~OUTPUT
             <<< Changes since last commit on master >>>
             #{@root}/components/a
@@ -182,7 +182,7 @@ RSpec.describe CobraCommander::Change do
           )
 
           expect do
-            described_class.new(@root, "full", "master").run!
+            described_class.new(tree, "full", "master").run!
           end.to output(<<~OUTPUT
             <<< Changes since last commit on master >>>
             #{@root}/components/e

--- a/spec/cobra_commander/cli_spec.rb
+++ b/spec/cobra_commander/cli_spec.rb
@@ -2,6 +2,8 @@
 
 require "spec_helper"
 
+require "securerandom"
+
 RSpec.describe "cli", type: :aruba do
   before(:all) { @root = AppHelper.root }
 
@@ -10,6 +12,17 @@ RSpec.describe "cli", type: :aruba do
       run_simple("cobra version", fail_on_error: true)
 
       expect(last_command_started).to have_output CobraCommander::VERSION
+    end
+  end
+
+  describe "creating a cache" do
+    it "saves the dependency structure in JSON format" do
+      run_simple("cobra cache #{@root} tmp/cobra-cache.json", fail_on_error: true)
+
+      expect(exist?("./tmp/cobra-cache.json")).to be true
+      expect("./tmp/cobra-cache.json").to have_file_content(
+        %({"name":"App","path":"#{@root}","type":"Ruby & JS","ancestry":[],"dependencies":[{"name":"a","path":"#{@root}/components/a","type":"Ruby","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"a","path":"#{@root}/components/a","type":"Ruby"}],"dependencies":[{"name":"g","path":"#{@root}/components/g","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"a","path":"#{@root}/components/a","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"}],"dependencies":[{"name":"e","path":"#{@root}/components/e","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"a","path":"#{@root}/components/a","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]},{"name":"f","path":"#{@root}/components/f","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"a","path":"#{@root}/components/a","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]}]}]},{"name":"c","path":"#{@root}/components/c","type":"Ruby","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"a","path":"#{@root}/components/a","type":"Ruby"}],"dependencies":[{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"a","path":"#{@root}/components/a","type":"Ruby"},{"name":"c","path":"#{@root}/components/c","type":"Ruby"}],"dependencies":[{"name":"g","path":"#{@root}/components/g","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"a","path":"#{@root}/components/a","type":"Ruby"},{"name":"c","path":"#{@root}/components/c","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"}],"dependencies":[{"name":"e","path":"#{@root}/components/e","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"a","path":"#{@root}/components/a","type":"Ruby"},{"name":"c","path":"#{@root}/components/c","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]},{"name":"f","path":"#{@root}/components/f","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"a","path":"#{@root}/components/a","type":"Ruby"},{"name":"c","path":"#{@root}/components/c","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]}]}]}]}]},{"name":"d","path":"#{@root}/components/d","type":"Ruby","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"d","path":"#{@root}/components/d","type":"Ruby"}],"dependencies":[{"name":"g","path":"#{@root}/components/g","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"d","path":"#{@root}/components/d","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"}],"dependencies":[{"name":"e","path":"#{@root}/components/e","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"d","path":"#{@root}/components/d","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]},{"name":"f","path":"#{@root}/components/f","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"d","path":"#{@root}/components/d","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]}]}]},{"name":"c","path":"#{@root}/components/c","type":"Ruby","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"d","path":"#{@root}/components/d","type":"Ruby"}],"dependencies":[{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"d","path":"#{@root}/components/d","type":"Ruby"},{"name":"c","path":"#{@root}/components/c","type":"Ruby"}],"dependencies":[{"name":"g","path":"#{@root}/components/g","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"d","path":"#{@root}/components/d","type":"Ruby"},{"name":"c","path":"#{@root}/components/c","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"}],"dependencies":[{"name":"e","path":"#{@root}/components/e","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"d","path":"#{@root}/components/d","type":"Ruby"},{"name":"c","path":"#{@root}/components/c","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]},{"name":"f","path":"#{@root}/components/f","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"d","path":"#{@root}/components/d","type":"Ruby"},{"name":"c","path":"#{@root}/components/c","type":"Ruby"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]}]}]}]}]},{"name":"h","path":"#{@root}/components/h","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"f","path":"#{@root}/components/f","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"h","path":"#{@root}/components/h","type":"JS"}],"dependencies":[]}]},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"}],"dependencies":[{"name":"g","path":"#{@root}/components/g","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"}],"dependencies":[{"name":"e","path":"#{@root}/components/e","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]},{"name":"f","path":"#{@root}/components/f","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]}]}]},{"name":"e","path":"#{@root}/components/e","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"}],"dependencies":[]},{"name":"f","path":"#{@root}/components/f","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"}],"dependencies":[]},{"name":"g","path":"#{@root}/components/g","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"}],"dependencies":[{"name":"e","path":"#{@root}/components/e","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]},{"name":"f","path":"#{@root}/components/f","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"},{"name":"g","path":"#{@root}/components/g","type":"JS"}],"dependencies":[]}]}]}]}) # rubocop:disable Metrics/LineLength
+      )
     end
   end
 
@@ -59,6 +72,90 @@ RSpec.describe "cli", type: :aruba do
 
       expect(last_command_started.output.strip.tr("\u00a0", " ")).to eq(expected_output)
     end
+
+    context "from a cache" do
+      it "outputs the tree of components" do
+        # Generate dependency cache
+        cache_file = write_cache(
+          %({"name":"App","path":"#{@root}","type":"Ruby & JS","ancestry":[],"dependencies":[{"name":"a","path":"#{@root}/components/a","type":"Ruby","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}]},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"c","path":"#{@root}/components/c","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"}],"dependencies":[]}]},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"}],"dependencies":[]}]}]}) # rubocop:disable Metrics/LineLength
+        )
+
+        # Use cache
+        run_simple("cobra ls #{@root} --cache #{cache_file}", fail_on_error: true)
+
+        expected_output = <<~OUTPUT
+          App
+          ├── a
+          ├── b
+          │   └── c
+          └── node_manifest
+              └── b
+        OUTPUT
+
+        # This converts a unicode non-breaking space with
+        # a normal space because editors.
+        expected_output = expected_output.strip.tr("\u00a0", " ")
+
+        expect(last_command_started.output.strip.tr("\u00a0", " ")).to eq(expected_output)
+      end
+
+      context "which is cold" do
+        let(:cache_file) { "tmp/#{SecureRandom.uuid}.json" }
+
+        before do
+          run_simple("cobra ls #{@root} --cache #{cache_file}", fail_on_error: false)
+        end
+
+        it "outputs the tree of components" do
+          expected_output = <<~OUTPUT
+            App
+            ├── a
+            │   ├── b
+            │   │   └── g
+            │   │       ├── e
+            │   │       └── f
+            │   └── c
+            │       └── b
+            │           └── g
+            │               ├── e
+            │               └── f
+            ├── d
+            │   ├── b
+            │   │   └── g
+            │   │       ├── e
+            │   │       └── f
+            │   └── c
+            │       └── b
+            │           └── g
+            │               ├── e
+            │               └── f
+            ├── h
+            │   └── f
+            └── node_manifest
+                ├── b
+                │   └── g
+                │       ├── e
+                │       └── f
+                ├── e
+                ├── f
+                └── g
+                    ├── e
+                    └── f
+          OUTPUT
+
+          # This converts a unicode non-breaking space with
+          # a normal space because editors.
+          expected_output = expected_output.strip.tr("\u00a0", " ")
+
+          expect(last_command_started.output.strip.tr("\u00a0", " ")).to eq(expected_output)
+        end
+
+        it "primes the cache" do
+          expect(exist?(cache_file)).to be true
+          expect(cache_file).to have_file_content(/"name":"App"/)
+        end
+      end
+    end
   end
 
   describe "generating a graph" do
@@ -91,6 +188,47 @@ RSpec.describe "cli", type: :aruba do
         run_simple("cobra graph #{@root} -f pdf", fail_on_error: true)
         expect(last_command_started.output).to_not include("Graph generated")
         expect(last_command_started).to have_output "FORMAT must be 'png' or 'dot'"
+      end
+    end
+
+    context "from a cache" do
+      context "which is warm" do
+        before do
+          cache_file = write_cache(
+            %({"name":"App","path":"#{@root}","type":"Ruby & JS","ancestry":[],"dependencies":[{"name":"a","path":"#{@root}/components/a","type":"Ruby","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}]},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"c","path":"#{@root}/components/c","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"}],"dependencies":[]}]},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"}],"dependencies":[]}]}]}) # rubocop:disable Metrics/LineLength
+          )
+
+          run_simple("cobra graph #{@root} --cache #{cache_file}", fail_on_error: true)
+        end
+
+        it "outputs explanation" do
+          expect(last_command_started.output).to include("Graph generated at #{`pwd`.chomp}")
+        end
+
+        it "creates file" do
+          expect(exist?("./graph.png")).to be true
+        end
+      end
+
+      context "which is cold" do
+        let(:cache_file) { "tmp/#{SecureRandom.uuid}.json" }
+
+        before do
+          run_simple("cobra graph #{@root} --cache #{cache_file}", fail_on_error: true)
+        end
+
+        it "outputs explanation" do
+          expect(last_command_started.output).to include("Graph generated at #{`pwd`.chomp}")
+        end
+
+        it "creates file" do
+          expect(exist?("./graph.png")).to be true
+        end
+
+        it "primes the cache" do
+          expect(exist?(cache_file)).to be true
+          expect(cache_file).to have_file_content(/"name":"App"/)
+        end
       end
     end
   end
@@ -144,22 +282,64 @@ RSpec.describe "cli", type: :aruba do
         expect(last_command_started.output).to_not include("Test scripts to run")
       end
     end
+
+    context "from a cache" do
+      context "which is warm" do
+        context "with full results" do
+          before do
+            cache_file = write_cache(
+              %({"name":"App","path":"#{@root}","type":"Ruby & JS","ancestry":[],"dependencies":[{"name":"a","path":"#{@root}/components/a","type":"Ruby","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}]},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"c","path":"#{@root}/components/c","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"}],"dependencies":[]}]},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"}],"dependencies":[]}]}]}) # rubocop:disable Metrics/LineLength
+            )
+            run_simple("cobra changes #{@root} -r full --cache #{cache_file}", fail_on_error: true)
+          end
+
+          it "outputs all headers" do
+            expect(last_command_started.output).to include("Changes since last commit on ")
+            expect(last_command_started.output).to include("Directly affected components")
+            expect(last_command_started.output).to include("Transitively affected components")
+            expect(last_command_started.output).to include("Test scripts to run")
+          end
+        end
+      end
+
+      context "which is cold" do
+        let(:cache_file) { "tmp/#{SecureRandom.uuid}.json" }
+
+        context "with full results" do
+          before do
+            run_simple("cobra changes #{@root} -r full --cache #{cache_file}", fail_on_error: true)
+          end
+
+          it "outputs all headers" do
+            expect(last_command_started.output).to include("Changes since last commit on ")
+            expect(last_command_started.output).to include("Directly affected components")
+            expect(last_command_started.output).to include("Transitively affected components")
+            expect(last_command_started.output).to include("Test scripts to run")
+          end
+
+          it "primes the cache" do
+            expect(exist?(cache_file)).to be true
+            expect(cache_file).to have_file_content(/"name":"App"/)
+          end
+        end
+      end
+    end
   end
 
-  describe "counting dependencies on a component in the tree" do
-    it "counts a component's direct dependency" do
+  describe "fetching dependents of a component in the tree" do
+    it "lists a component's direct dependents" do
       run_simple("cobra dependents_of node_manifest -a #{@root} --format=list", fail_on_error: true)
 
       expect(last_command_started.output.strip.split("\n")).to match(["App"])
     end
 
-    it "counts a component's transient dependency" do
+    it "lists a component's transient dependents" do
       run_simple("cobra dependents_of g -a #{@root} --format=list", fail_on_error: true)
 
       expect(last_command_started.output.strip.split("\n")).to match(%w[App a b c d node_manifest])
     end
 
-    it "counts a component's transient dependency" do
+    it "counts a component's transient dependents" do
       run_simple("cobra dependents_of g -a #{@root} --format=count", fail_on_error: true)
 
       expect(last_command_started.output.to_i).to eq(6)
@@ -169,6 +349,35 @@ RSpec.describe "cli", type: :aruba do
       run_simple("cobra dependents_of non_existent -a #{@root} --format=list", fail_on_error: true)
 
       expect(last_command_started.output.strip.split("\n")).to match([])
+    end
+
+    context "from a cache" do
+      it "lists a component's dependents" do
+        cache_file = write_cache(
+          %({"name":"App","path":"#{@root}","type":"Ruby & JS","ancestry":[],"dependencies":[{"name":"a","path":"#{@root}/components/a","type":"Ruby","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}]},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"c","path":"#{@root}/components/c","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"}],"dependencies":[]}]},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"}],"dependencies":[]}]}]}) # rubocop:disable Metrics/LineLength
+        )
+
+        run_simple("cobra dependents_of c -a #{@root} --format=list --cache #{cache_file}", fail_on_error: true)
+
+        expect(last_command_started.output.strip.split("\n")).to match(%w[App b])
+      end
+
+      context "which is cold" do
+        let(:cache_file) { "tmp/#{SecureRandom.uuid}.json" }
+
+        before do
+          run_simple("cobra dependents_of c -a #{@root} --format=list --cache #{cache_file}", fail_on_error: true)
+        end
+
+        it "lists a component's dependents" do
+          expect(last_command_started.output.strip.split("\n")).to match(%w[App a d])
+        end
+
+        it "primes the cache" do
+          expect(exist?(cache_file)).to be true
+          expect(cache_file).to have_file_content(/"name":"App"/)
+        end
+      end
     end
   end
 
@@ -190,5 +399,41 @@ RSpec.describe "cli", type: :aruba do
 
       expect(last_command_started.output.strip.split("\n")).to match(%w[b g e f c])
     end
+
+    context "from a cache" do
+      it "lists a component's direct dependency" do
+        cache_file = write_cache(
+          %({"name":"App","path":"#{@root}","type":"Ruby & JS","ancestry":[],"dependencies":[{"name":"a","path":"#{@root}/components/a","type":"Ruby","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}]},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"c","path":"#{@root}/components/c","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS"}],"dependencies":[]}]},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"}],"dependencies":[{"name":"b","path":"#{@root}/components/b","type":"Ruby & JS","ancestry":[{"name":"App","path":"#{@root}","type":"Ruby & JS"},{"name":"node_manifest","path":"#{@root}/node_manifest","type":"JS"}],"dependencies":[]}]}]}) # rubocop:disable Metrics/LineLength
+        )
+
+        run_simple("cobra dependencies_of b -a #{@root} --cache #{cache_file}", fail_on_error: true)
+
+        expect(last_command_started.output.strip.split("\n")).to match(%w[c])
+      end
+    end
+
+    context "which is cold" do
+      let(:cache_file) { "tmp/#{SecureRandom.uuid}.json" }
+
+      before do
+        run_simple("cobra dependencies_of b -a #{@root} --cache #{cache_file}", fail_on_error: true)
+      end
+
+      it "lists a component's direct dependency" do
+        expect(last_command_started.output.strip.split("\n")).to match(%w[g e f])
+      end
+
+      it "primes the cache" do
+        expect(exist?(cache_file)).to be true
+        expect(cache_file).to have_file_content(/"name":"App"/)
+      end
+    end
+  end
+
+  def write_cache(contents)
+    tempfile = Tempfile.new
+    tempfile.write(contents)
+    tempfile.rewind
+    tempfile.path
   end
 end

--- a/spec/cobra_commander/graph_spec.rb
+++ b/spec/cobra_commander/graph_spec.rb
@@ -44,12 +44,12 @@ RSpec.describe CobraCommander::Graph do
       }
     end
 
-    before do
-      allow_any_instance_of(CobraCommander::ComponentTree).to receive(:to_h).and_return(hash_tree)
+    let(:tree) do
+      double(to_h: hash_tree)
     end
 
     it "correctly generates graph.dot" do
-      CobraCommander::Graph.new(".", "dot").generate!
+      CobraCommander::Graph.new(tree, "dot").generate!
 
       native_dot = File.join(root, "native_graph.dot")
       generated_dot = File.join(root, "graph.dot")


### PR DESCRIPTION
This helps when we want to repeatedly run cobra on an app whose component tree hasn't changed, such as in a CI build. Calculating the component tree is the most expensive part of invoking cobra_commander.