### PR TITLE
Gets workspaces from yarn command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ before_install:
   - "find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete"
   - gem install bundler:"$BUNDLER_VERSION"
   - sudo apt-get -qq install graphviz
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0 
+  - export PATH="$HOME/.yarn/bin:$PATH"
 rvm:
   - 2.5.1
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Changes implementation of how we get the declared workspaces. Now we use `yarn workspaces info` instead of reading it from the list in `package.json`. PR [#34](https://github.com/powerhome/cobra_commander/pull/34)
+* Better supports yarn workspaces globbing by delegating to yarn to calculate the list of components rather than re-implementing in Ruby. PR [#34](https://github.com/powerhome/cobra_commander/pull/34)
 
 ## Version 0.6.0 - 2019-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Changes implementation of how we get the declared workspaces. Now we use `yarn workspaces info` instead of reading it from the list in `package.json`. PR [#34](https://github.com/powerhome/cobra_commander/pull/34)
+
 ## Version 0.6.0 - 2019-07-03
 
 * Tracks package.json `workspaces` in addition to `dependencies` and `devDependencies`. PR [#31](https://github.com/powerhome/cobra_commander/pull/31)

--- a/lib/cobra_commander/calculated_component_tree.rb
+++ b/lib/cobra_commander/calculated_component_tree.rb
@@ -123,7 +123,6 @@ module CobraCommander
       def build_workspaces(workspaces)
         return [] if workspaces.nil?
 
-        yarn_workspaces = read_workspaces
         yarn_workspaces.map do |_, component|
           { name: component["location"].split("/")[-1], path: component["location"] }
         end
@@ -131,10 +130,11 @@ module CobraCommander
 
     private
 
-      def read_workspaces
-        output, = Open3.capture2("yarn workspaces info", chdir: @root_path)
-        striped_output = output.lines[1..-2].join
-        JSON.parse(striped_output)
+      def yarn_workspaces
+        @yarn_workspaces ||= begin
+          output, = Open3.capture2("yarn workspaces info --silent", chdir: @root_path)
+          JSON.parse(output)
+        end
       end
     end
   end

--- a/lib/cobra_commander/calculated_component_tree.rb
+++ b/lib/cobra_commander/calculated_component_tree.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cobra_commander/component_tree"
+require "open3"
 
 module CobraCommander
   # Represents a dependency tree in a given context
@@ -121,25 +122,19 @@ module CobraCommander
 
       def build_workspaces(workspaces)
         return [] if workspaces.nil?
-        workspaces.map do |workspace|
-          glob = "#{@root_path}/#{workspace}/package.json"
-          workspace_dependencies = Dir.glob(glob)
-          workspace_dependencies.map do |wd|
-            { name: component_name(wd), path: component_path(wd) }
-          end
-        end.flatten
+
+        yarn_workspaces = read_workspaces
+        yarn_workspaces.map do |_, component|
+          { name: component["location"].split("/")[-1], path: component["location"] }
+        end
       end
 
     private
 
-      def component_name(dir)
-        component_path(dir).split("/")[-1]
-      end
-
-      def component_path(dir)
-        return dir.split("/package.json")[0] if @root_path == "."
-
-        dir.split(@root_path)[-1].split("/package.json")[0]
+      def read_workspaces
+        output, = Open3.capture2("yarn workspaces info", chdir: @root_path)
+        striped_output = output.lines[1..-2].join
+        JSON.parse(striped_output)
       end
     end
   end

--- a/spec/fixtures/app/package.json
+++ b/spec/fixtures/app/package.json
@@ -4,6 +4,7 @@
   "description": "Some description",
   "author": "Garett Arrowood",
   "license": "UNLICENSED",
+  "private": true,
   "workspaces": [
     "components/h"
   ],


### PR DESCRIPTION
Changes implementation, instead of iterating over the items declared on workspaces, we instead use `yarn workspaces info` result to get the list of workspaces.