### PR TITLE
Allows user to limit the concurrency of cobra exec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/bundler${{ matrix.bundler }}.gemfile
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler: ${{ matrix.bundler }}
@@ -41,8 +40,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0
-    - name: rubocop
-      uses: reviewdog/action-rubocop@v1
+    - uses: reviewdog/action-rubocop@v1
       with:
         rubocop_version: 0.88.0
         filter_mode: nofilter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0
     - name: rubocop
       uses: reviewdog/action-rubocop@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,26 @@
 
 ## Unreleased
 
+* Add concurrency limit to multi exec [#57](https://github.com/powerhome/cobra_commander/pull/57)
+* Ruby 3.0 compatibility [#55](https://github.com/powerhome/cobra_commander/pull/55)
+
+## Version 0.10.0 - 2021-02-25
+
+* Add support for Bundler 2 [#54](https://github.com/powerhome/cobra_commander/pull/54)
+* Add support for Ruby 2.7 [#53](https://github.com/powerhome/cobra_commander/pull/53)
+
+## Version 0.9.2 -
+
+* Another fix for binstubs [#51](https://github.com/powerhome/cobra_commander/pull/51)
+
+## Version 0.9.1 -
+
+* Replace bundler encapsulation violation by LockfileParser [#48](https://github.com/powerhome/cobra_commander/pull/48)
+* Fix bundle binstubs [#50](https://github.com/powerhome/cobra_commander/pull/50)
+
 ## Version 0.9.0 - 2020-08-26
 
-* Add support for parallel task execution to `cobra exec`.
+* Add support for parallel task execution to `cobra exec` [#49](https://github.com/powerhome/cobra_commander/pull/49)
 
 ## Version 0.8.1 - 2020-07-29
 

--- a/cobra_commander.gemspec
+++ b/cobra_commander.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bundler"
+  spec.add_dependency "concurrent-ruby", "~> 1.1"
   spec.add_dependency "ruby-graphviz", "~> 1.2.3"
   spec.add_dependency "thor", ["< 2.0", ">= 0.18.1"]
   spec.add_dependency "tty-command", "~> 0.10.0"

--- a/lib/cobra_commander/cli.rb
+++ b/lib/cobra_commander/cli.rb
@@ -2,6 +2,7 @@
 
 require "thor"
 require "fileutils"
+require "concurrent-ruby"
 
 require "cobra_commander"
 require "cobra_commander/affected"
@@ -12,6 +13,8 @@ require "cobra_commander/output"
 module CobraCommander
   # Implements the tool's CLI
   class CLI < Thor
+    DEFAULT_CONCURRENCY = (Concurrent.processor_count / 2.0).ceil
+
     class_option :app, default: Dir.pwd, aliases: "-a", type: :string
     class_option :js, default: false, type: :boolean, desc: "Consider only the JS dependency graph"
     class_option :ruby, default: false, type: :boolean, desc: "Consider only the Ruby dependency graph"
@@ -36,7 +39,8 @@ module CobraCommander
                                        "Defaults to all components."
     method_option :dependencies, type: :boolean, desc: "Run the command on each dependency of a given component"
     method_option :dependents, type: :boolean, desc: "Run the command on each dependency of a given component"
-    method_option :concurrency, type: :numeric, default: 3, aliases: "-c", desc: "Max number of jobs to run concurrently"
+    method_option :concurrency, type: :numeric, default: DEFAULT_CONCURRENCY, aliases: "-c",
+                                desc: "Max number of jobs to run concurrently"
     def exec(command_or_component, command = nil)
       CobraCommander::Executor.exec(
         components: components_filtered(command && command_or_component),

--- a/lib/cobra_commander/cli.rb
+++ b/lib/cobra_commander/cli.rb
@@ -36,10 +36,12 @@ module CobraCommander
                                        "Defaults to all components."
     method_option :dependencies, type: :boolean, desc: "Run the command on each dependency of a given component"
     method_option :dependents, type: :boolean, desc: "Run the command on each dependency of a given component"
+    method_option :concurrency, type: :numeric, default: 3, aliases: "-c", desc: "Max number of jobs to run concurrently"
     def exec(command_or_component, command = nil)
       CobraCommander::Executor.exec(
-        components_filtered(command && command_or_component),
-        command || command_or_component
+        components: components_filtered(command && command_or_component),
+        command: command || command_or_component,
+        concurrency: options.concurrency
       )
     end
 

--- a/lib/cobra_commander/executor.rb
+++ b/lib/cobra_commander/executor.rb
@@ -6,14 +6,14 @@ require_relative "executor/multi_exec"
 module CobraCommander
   # Execute commands on all components of a ComponentTree
   module Executor
-    def self.exec(components, command, output = $stdout, status_output = $stderr)
+    def self.exec(components:, command:, concurrency:, output: $stdout, status_output: $stderr)
       components = Array(components)
       exec = if components.size == 1
                ComponentExec.new(components.first)
              else
-               MultiExec.new(components)
+               MultiExec.new(components, concurrency: concurrency, spin_output: status_output)
              end
-      exec.run(command, output: output, spin_output: status_output)
+      exec.run(command, output: output)
     end
   end
 end

--- a/lib/cobra_commander/executor/multi_exec.rb
+++ b/lib/cobra_commander/executor/multi_exec.rb
@@ -22,11 +22,11 @@ module CobraCommander
         @components.each do |component|
           register_job(command: command, component: component,
                        output: buffer, stderr: :stdout,
-                       only_output_on_error: true,
-                       **kwargs)
+                       only_output_on_error: true, **kwargs)
         end
         @multi.auto_spin
         output << buffer.string
+        @multi.success?
       end
 
     private

--- a/spec/cobra_commander/executor/multi_exec_spec.rb
+++ b/spec/cobra_commander/executor/multi_exec_spec.rb
@@ -27,4 +27,12 @@ RSpec.describe CobraCommander::Executor::MultiExec do
     expect(spin_output.string).to match(/\[DONE\](\e\[0m)? node_manifest/)
     expect(spin_output.string).to match(/\[DONE\](\e\[0m)? g/)
   end
+
+  it "fails when the command fail" do
+    expect(subject.run("lol", output: cmmd_output)).to_not be true
+  end
+
+  it "succeeds when it succeed" do
+    expect(subject.run("true", output: cmmd_output)).to be true
+  end
 end

--- a/spec/cobra_commander/executor/multi_exec_spec.rb
+++ b/spec/cobra_commander/executor/multi_exec_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe CobraCommander::Executor::MultiExec do
   let(:spin_output) { StringIO.new }
   let(:cmmd_output) { StringIO.new }
   let(:component_e) { fixture_umbrella.find("e") }
-  subject { CobraCommander::Executor::MultiExec.new(component_e.dependents) }
+  subject { CobraCommander::Executor::MultiExec.new(component_e.dependents, concurrency: 1, spin_output: spin_output) }
   before do
     allow(spin_output).to receive(:tty?) { true }
   end
 
   it "executes in the context of each given component" do
-    subject.run("echo 'I am at' $PWD", output: cmmd_output, spin_output: spin_output, only_output_on_error: false)
+    subject.run("echo 'I am at' $PWD", output: cmmd_output, only_output_on_error: false)
 
     expect(cmmd_output.string).to match(%r{I am at .*components/b$})
     expect(cmmd_output.string).to match(/I am at .*node_manifest$/)
@@ -21,7 +21,7 @@ RSpec.describe CobraCommander::Executor::MultiExec do
   end
 
   it "prints the status of each component" do
-    subject.run("echo 'I am at' $PWD", output: cmmd_output, spin_output: spin_output)
+    subject.run("echo 'I am at' $PWD", output: cmmd_output)
 
     expect(spin_output.string).to match(/\[DONE\](\e\[0m)? b/)
     expect(spin_output.string).to match(/\[DONE\](\e\[0m)? node_manifest/)

--- a/spec/cobra_commander/executor_spec.rb
+++ b/spec/cobra_commander/executor_spec.rb
@@ -7,14 +7,16 @@ RSpec.describe CobraCommander::Executor do
   describe ".exec" do
     it "executes the given command with full output when its a single component" do
       output = StringIO.new
-      CobraCommander::Executor.exec(fixture_umbrella.find("a"), "pwd", output)
+      CobraCommander::Executor.exec(components: fixture_umbrella.find("a"), command: "pwd",
+                                    concurrency: 1, output: output)
 
       expect(output.string).to eq "#{fixture_app}/components/a\n"
     end
 
     it "executes the given command with status output only when multiple components are given" do
       output = StringIO.new
-      CobraCommander::Executor.exec(fixture_umbrella.components, "pwd", output, output)
+      CobraCommander::Executor.exec(components: fixture_umbrella.components, command: "pwd",
+                                    concurrency: 1, output: output, status_output: output)
 
       expect(output.string).to_not include("[DONE]")
     end


### PR DESCRIPTION
`cobra exec` runs everything at the same time right now, consuming a lot of CPU and in some cases opening too many files in the OS.

This PR introduces the argument `--concurrency` or `-c` to `cobra exec` so the user can limit the concurrency. This argument defaults to half the number of processors of the current machine.