### PR TITLE
Include self filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add `--self` and `--no-self` filters to `cobra exec` and `cobra ls`, defaults to `--self` [#61](https://github.com/powerhome/cobra_commander/pull/61)
+
 ## Version 0.11.0 - 2021-04-23
 
 * Add concurrency limit to multi exec [#57](https://github.com/powerhome/cobra_commander/pull/57)

--- a/lib/cobra_commander/cli.rb
+++ b/lib/cobra_commander/cli.rb
@@ -13,6 +13,8 @@ require "cobra_commander/output"
 module CobraCommander
   # Implements the tool's CLI
   class CLI < Thor
+    require "cobra_commander/cli/filters"
+
     DEFAULT_CONCURRENCY = (Concurrent.processor_count / 2.0).ceil
 
     class_option :app, default: Dir.pwd, aliases: "-a", type: :string
@@ -73,32 +75,10 @@ module CobraCommander
       Change.new(umbrella, options.results, options.branch).run!
     end
 
-    private_class_method def self.filter_options(dependents:, dependencies:)
-      method_option :dependencies, type: :boolean, aliases: "-d", desc: dependencies
-      method_option :dependents, type: :boolean, aliases: "-D", desc: dependents
-    end
-
   private
 
     def umbrella
       @umbrella ||= CobraCommander.umbrella(options.app, yarn: options.js, bundler: options.ruby)
-    end
-
-    def find_component(name)
-      return umbrella.root unless name
-
-      umbrella.find(name) || error("Component #{name} not found, try one of `cobra ls`") || exit(1)
-    end
-
-    def components_filtered(component_name)
-      return umbrella.components unless component_name
-
-      component = find_component(component_name)
-
-      return component.deep_dependencies if options.dependencies
-      return component.deep_dependents if options.dependents
-
-      [component]
     end
   end
 end

--- a/lib/cobra_commander/cli.rb
+++ b/lib/cobra_commander/cli.rb
@@ -25,10 +25,8 @@ module CobraCommander
     end
 
     desc "ls [component]", "Lists the components in the context of a given component or umbrella"
-    method_option :dependencies, type: :boolean, aliases: "-d",
-                                 desc: "Run the command on each dependency of a given component"
-    method_option :dependents, type: :boolean, aliases: "-D",
-                               desc: "Run the command on each dependency of a given component"
+    filter_options dependents: "Lists all dependents of a given component",
+                   dependencies: "Lists all dependencies of a given component"
     method_option :total, type: :boolean, aliases: "-t", desc: "Prints the total count of components"
     def ls(component = nil)
       components = components_filtered(component)
@@ -37,8 +35,8 @@ module CobraCommander
 
     desc "exec [component] <command>", "Executes the command in the context of a given component or set thereof. " \
                                        "Defaults to all components."
-    method_option :dependencies, type: :boolean, desc: "Run the command on each dependency of a given component"
-    method_option :dependents, type: :boolean, desc: "Run the command on each dependency of a given component"
+    filter_options dependents: "Run the command on each dependent of a given component",
+                   dependencies: "Run the command on each dependency of a given component"
     method_option :concurrency, type: :numeric, default: DEFAULT_CONCURRENCY, aliases: "-c",
                                 desc: "Max number of jobs to run concurrently"
     def exec(command_or_component, command = nil)
@@ -73,6 +71,11 @@ module CobraCommander
     method_option :branch, default: "master", aliases: "-b", desc: "Specified target to calculate against"
     def changes
       Change.new(umbrella, options.results, options.branch).run!
+    end
+
+    private_class_method def self.filter_options(dependents:, dependencies:)
+      method_option :dependencies, type: :boolean, aliases: "-d", desc: dependencies
+      method_option :dependents, type: :boolean, aliases: "-D", desc: dependents
     end
 
   private

--- a/lib/cobra_commander/cli/filters.rb
+++ b/lib/cobra_commander/cli/filters.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module CobraCommander
+  # @private
+  class CLI
+    private_class_method def self.filter_options(dependents:, dependencies:)
+      method_option :dependencies, type: :boolean, aliases: "-d", desc: dependencies
+      method_option :dependents, type: :boolean, aliases: "-D", desc: dependents
+      method_option :self, type: :boolean, desc: "Include the own component"
+    end
+
+  private
+
+    def find_component(name)
+      return umbrella.root unless name
+
+      umbrella.find(name) || error("Component #{name} not found, try one of `cobra ls`") || exit(1)
+    end
+
+    def components_filtered(component_name)
+      return umbrella.components unless component_name
+
+      component = find_component(component_name)
+      components = options.self ? [component] : []
+      components.concat component.deep_dependencies if options.dependencies
+      components.concat component.deep_dependents if options.dependents
+      components
+    end
+  end
+end

--- a/lib/cobra_commander/cli/filters.rb
+++ b/lib/cobra_commander/cli/filters.rb
@@ -6,7 +6,7 @@ module CobraCommander
     private_class_method def self.filter_options(dependents:, dependencies:)
       method_option :dependencies, type: :boolean, aliases: "-d", desc: dependencies
       method_option :dependents, type: :boolean, aliases: "-D", desc: dependents
-      method_option :self, type: :boolean, desc: "Include the own component"
+      method_option :self, type: :boolean, default: true, desc: "Include the own component"
     end
 
   private


### PR DESCRIPTION
`cobra ls` and `cobra exec` can both take filters in the format of `--dependents` and `--dependencies`. These filters do not include the component itself. Whether it's debatable if the component is a dependency of itself, it's not debatable that the majority of the time where we use these filters we want to include the component itself in there. The majority of times where I have to run `cobra exec --dependents` of something I find myself running the same command for that component as well.

This PR adds `--self` and `--no-self`, where `--self` is the default behavior.