### PR TITLE
Switch from rubocop to standardrb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0
+        bundler: 2
     - name: Run tests
       run: bundle exec rake standard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,7 @@ jobs:
       with:
         ruby-version: 3.0
         bundler: 2
+    - name: Bundle
+      run: bundle
     - name: Run tests
       run: bundle exec rake standard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
   lint:
     name: Lint Ruby
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/bundler2.gemfile
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,12 @@ jobs:
   lint:
     name: Lint Ruby
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: gemfiles/bundler2.gemfile
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0
-        bundler: 2
     - name: Bundle
       run: bundle
-    - name: Run tests
+    - name: Run standard
       run: bundle exec rake standard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,5 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0
-    - uses: reviewdog/action-rubocop@v1
-      with:
-        rubocop_version: 0.88.0
-        filter_mode: nofilter
-        fail_on_error: true
-        rubocop_extensions: ""
-        github_token: ${{ secrets.github_token }}
+    - name: Run tests
+      run: bundle exec rake standard

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-
+require "standard/rake"
 require "rspec/core/rake_task"
+
 RSpec::Core::RakeTask.new(:spec)
 
-require "rubocop/rake_task"
-RuboCop::RakeTask.new
-
-task default: %i[spec rubocop]
+task default: %i[spec standard]

--- a/cobra_commander.gemspec
+++ b/cobra_commander.gemspec
@@ -5,32 +5,32 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "cobra_commander/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "cobra_commander"
-  spec.version       = CobraCommander::VERSION
-  spec.authors       = [
+  spec.name = "cobra_commander"
+  spec.version = CobraCommander::VERSION
+  spec.authors = [
     "Ben Langfeld",
     "Garett Arrowood",
-    "Carlos Palhares",
+    "Carlos Palhares"
   ]
   spec.email = [
     "blangfeld@powerhrg.com",
     "garett.arrowood@powerhrg.com",
-    "carlos.palhares@powerhrg.com",
+    "carlos.palhares@powerhrg.com"
   ]
-  spec.summary       = "Tools for working with Component Based Rails Apps"
-  spec.description   = <<~DESCRIPTION
+  spec.summary = "Tools for working with Component Based Rails Apps"
+  spec.description = <<~DESCRIPTION
     Tools for working with Component Based Rails Apps (see http://shageman.github.io/cbra.info/).
     Includes tools for graphing the components of an app and their relationships, as well as selectively
     testing components based on changes made.
   DESCRIPTION
-  spec.homepage      = "http://tech.powerhrg.com/cobra_commander/"
-  spec.license       = "MIT"
+  spec.homepage = "http://tech.powerhrg.com/cobra_commander/"
+  spec.license = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bundler"
@@ -47,5 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.5"
-  spec.add_development_dependency "rubocop", "0.88.0"
+  spec.add_development_dependency "standard", ">= 1.3.0"
 end

--- a/lib/cobra_commander/affected.rb
+++ b/lib/cobra_commander/affected.rb
@@ -34,12 +34,12 @@ module CobraCommander
         component_names: names,
         languages: {
           ruby: contains_ruby?,
-          javascript: contains_js?,
-        },
+          javascript: contains_js?
+        }
       }.to_json
     end
 
-  private
+    private
 
     def run!
       @transitively = Set.new
@@ -68,7 +68,7 @@ module CobraCommander
       {
         name: component.name,
         path: component.root_paths,
-        type: component.sources.keys.map(&:to_s).map(&:capitalize).join(" & "),
+        type: component.sources.keys.map(&:to_s).map(&:capitalize).join(" & ")
       }
     end
 

--- a/lib/cobra_commander/affected.rb
+++ b/lib/cobra_commander/affected.rb
@@ -25,17 +25,14 @@ module CobraCommander
       @transitively.map(&method(:affected_component))
     end
 
-    def json_representation # rubocop:disable Metrics/MethodLength
+    def json_representation
       {
         changed_files: @changes,
         directly_affected_components: directly,
         transitively_affected_components: transitively,
         test_scripts: scripts,
         component_names: names,
-        languages: {
-          ruby: contains_ruby?,
-          javascript: contains_js?
-        }
+        languages: {ruby: contains_ruby?, javascript: contains_js?}
       }.to_json
     end
 

--- a/lib/cobra_commander/change.rb
+++ b/lib/cobra_commander/change.rb
@@ -28,7 +28,7 @@ module CobraCommander
       puts e.message
     end
 
-  private
+    private
 
     def show_full
       changes_since_last_commit

--- a/lib/cobra_commander/cli.rb
+++ b/lib/cobra_commander/cli.rb
@@ -28,7 +28,7 @@ module CobraCommander
 
     desc "ls [component]", "Lists the components in the context of a given component or umbrella"
     filter_options dependents: "Lists all dependents of a given component",
-                   dependencies: "Lists all dependencies of a given component"
+      dependencies: "Lists all dependencies of a given component"
     method_option :total, type: :boolean, aliases: "-t", desc: "Prints the total count of components"
     def ls(component = nil)
       components = components_filtered(component)
@@ -38,17 +38,17 @@ module CobraCommander
     desc "exec [component] <command>", "Executes the command in the context of a given component or set thereof. " \
                                        "Defaults to all components."
     filter_options dependents: "Run the command on each dependent of a given component",
-                   dependencies: "Run the command on each dependency of a given component"
+      dependencies: "Run the command on each dependency of a given component"
     method_option :concurrency, type: :numeric, default: DEFAULT_CONCURRENCY, aliases: "-c",
                                 desc: "Max number of jobs to run concurrently"
     method_option :interactive, type: :boolean, default: true, aliases: "-i",
-                                desc: "Runs in interactive mode to allow the user to inspect the output of each component"
+                                desc: "Runs in interactive mode to allow the user to inspect the output of each " \
+                                      "component"
     def exec(command_or_component, command = nil)
       results = CobraCommander::Executor.exec(
         components: components_filtered(command && command_or_component),
         command: command || command_or_component,
-        concurrency: options.concurrency,
-        status_output: $stderr
+        concurrency: options.concurrency, status_output: $stderr
       )
       if options.interactive && results.size > 1
         CobraCommander::Output::InteractivePrinter.run(results, $stdout)
@@ -83,7 +83,7 @@ module CobraCommander
       Change.new(umbrella, options.results, options.branch).run!
     end
 
-  private
+    private
 
     def umbrella
       @umbrella ||= CobraCommander.umbrella(options.app, yarn: options.js, bundler: options.ruby)

--- a/lib/cobra_commander/cli/filters.rb
+++ b/lib/cobra_commander/cli/filters.rb
@@ -9,7 +9,7 @@ module CobraCommander
       method_option :self, type: :boolean, default: true, desc: "Include the own component"
     end
 
-  private
+    private
 
     def find_component(name)
       return umbrella.root unless name

--- a/lib/cobra_commander/component.rb
+++ b/lib/cobra_commander/component.rb
@@ -45,8 +45,8 @@ module CobraCommander
 
     def dependencies
       @dependencies ||= @dependency_names.sort
-                                         .map(&@umbrella.method(:find))
-                                         .compact
+        .map(&@umbrella.method(:find))
+        .compact
     end
   end
 end

--- a/lib/cobra_commander/dependencies/bundler.rb
+++ b/lib/cobra_commander/dependencies/bundler.rb
@@ -21,11 +21,11 @@ module CobraCommander
 
       def components
         components_source.specs.map do |spec|
-          { path: spec.loaded_from, name: spec.name, dependencies: spec.dependencies.map(&:name) }
+          {path: spec.loaded_from, name: spec.name, dependencies: spec.dependencies.map(&:name)}
         end
       end
 
-    private
+      private
 
       def lockfile
         @lockfile ||= ::Bundler::LockfileParser.new(::Bundler.read_file(path))

--- a/lib/cobra_commander/dependencies/yarn/package.rb
+++ b/lib/cobra_commander/dependencies/yarn/package.rb
@@ -24,10 +24,10 @@ module CobraCommander
 
         def dependencies
           json.fetch("dependencies", {})
-              .merge(json.fetch("devDependencies", {}))
+            .merge(json.fetch("devDependencies", {}))
         end
 
-      private
+        private
 
         def json
           @json ||= JSON.parse(File.read(@path))

--- a/lib/cobra_commander/dependencies/yarn_workspace.rb
+++ b/lib/cobra_commander/dependencies/yarn_workspace.rb
@@ -28,11 +28,11 @@ module CobraCommander
 
       def components
         @repo.specs.map do |spec|
-          { path: spec.path, name: untag(spec.name), dependencies: spec.dependencies.keys.map(&method(:untag)) }
+          {path: spec.path, name: untag(spec.name), dependencies: spec.dependencies.keys.map(&method(:untag))}
         end
       end
 
-    private
+      private
 
       def load_workspace_packages
         workspace_spec.map do |_name, spec|

--- a/lib/cobra_commander/executor.rb
+++ b/lib/cobra_commander/executor.rb
@@ -8,7 +8,7 @@ module CobraCommander
   module Executor
     def self.exec(components:, command:, concurrency:, status_output:)
       Concurrent.new(components, concurrency: concurrency, spin_output: status_output)
-                .exec(command)
+        .exec(command)
     end
   end
 end

--- a/lib/cobra_commander/executor/concurrent.rb
+++ b/lib/cobra_commander/executor/concurrent.rb
@@ -23,7 +23,7 @@ module CobraCommander
         @results
       end
 
-    private
+      private
 
       def pastel
         @pastel ||= Pastel.new
@@ -33,7 +33,7 @@ module CobraCommander
         @spinner_options ||= {
           format: :bouncing,
           success_mark: pastel.green("[DONE]"),
-          error_mark: pastel.red("[ERROR]"),
+          error_mark: pastel.red("[ERROR]")
         }
       end
 

--- a/lib/cobra_commander/executor/context.rb
+++ b/lib/cobra_commander/executor/context.rb
@@ -4,6 +4,8 @@ require "tty-command"
 
 module CobraCommander
   module Executor
+    # Represents a component context to execute a command
+    # @private
     class Context
       attr_reader :component, :command
 
@@ -33,7 +35,7 @@ module CobraCommander
         results.join("\n")
       end
 
-    private
+      private
 
       def isolate_bundle(&block)
         if Bundler.respond_to?(:with_unbundled_env)

--- a/lib/cobra_commander/output/ascii_tree.rb
+++ b/lib/cobra_commander/output/ascii_tree.rb
@@ -6,9 +6,9 @@ module CobraCommander
   module Output
     # Prints the tree in a nice tree form
     class AsciiTree
-      SPACE  = "    "
-      BAR    = "│   "
-      TEE    = "├── "
+      SPACE = "    "
+      BAR = "│   "
+      TEE = "├── "
       CORNER = "└── "
 
       def initialize(component)
@@ -22,7 +22,7 @@ module CobraCommander
         end.string
       end
 
-    private
+      private
 
       def list_dependencies(io, component, outdents = [])
         component.dependencies.each do |dep|

--- a/lib/cobra_commander/output/graph_viz.rb
+++ b/lib/cobra_commander/output/graph_viz.rb
@@ -17,7 +17,7 @@ module CobraCommander
       end
 
       private_class_method def self.extract_format(output)
-        format = output[-3..]
+        format = output[-3..-1] # standard:disable Style/SlicingWithRange
         return format if %w[png dot].include?(format)
 
         raise ArgumentError, "output format must be 'png' or 'dot'"

--- a/lib/cobra_commander/output/graph_viz.rb
+++ b/lib/cobra_commander/output/graph_viz.rb
@@ -17,7 +17,7 @@ module CobraCommander
       end
 
       private_class_method def self.extract_format(output)
-        format = output[-3..-1]
+        format = output[-3..]
         return format if %w[png dot].include?(format)
 
         raise ArgumentError, "output format must be 'png' or 'dot'"

--- a/lib/cobra_commander/output/interactive_printer.rb
+++ b/lib/cobra_commander/output/interactive_printer.rb
@@ -8,8 +8,8 @@ module CobraCommander
     # Runs an interactive output printer
     class InteractivePrinter
       pastel = Pastel.new
-      SUCCESS = "#{pastel.green('✔')} %s"
-      ERROR = "#{pastel.red('✖')} %s"
+      SUCCESS = "#{pastel.green("✔")} %s"
+      ERROR = "#{pastel.red("✖")} %s"
       BYE = pastel.decorate("\n\n👋 Bye!", :white, :on_black, :bold).freeze
 
       def self.run(contexts, output)
@@ -19,7 +19,7 @@ module CobraCommander
       def initialize(contexts)
         @prompt = TTY::Prompt.new
         @options = contexts.sort(&method(:sort_contexts))
-                           .reduce({}) do |options, context|
+          .reduce({}) do |options, context|
           template = context.success? ? SUCCESS : ERROR
           options.merge format(template, context.component_name) => context
         end
@@ -34,7 +34,7 @@ module CobraCommander
         output.puts BYE
       end
 
-    private
+      private
 
       def sort_contexts(context_a, context_b)
         if context_a.success? == context_b.success?

--- a/spec/cobra_commander/affected_spec.rb
+++ b/spec/cobra_commander/affected_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe CobraCommander::Affected do
           {
             name: "a",
             path: ["#{fixture_app}/components/a"],
-            type: "Bundler",
-          },
+            type: "Bundler"
+          }
         ]
       )
     end
@@ -67,8 +67,8 @@ RSpec.describe CobraCommander::Affected do
           {
             name: "b",
             path: ["#{fixture_app}/components/b"],
-            type: "Yarn & Bundler",
-          },
+            type: "Yarn & Bundler"
+          }
         ]
       )
     end
@@ -79,38 +79,38 @@ RSpec.describe CobraCommander::Affected do
           {
             name: "a",
             path: ["#{fixture_app}/components/a"],
-            type: "Bundler",
+            type: "Bundler"
           },
           {
             name: "c",
             path: ["#{fixture_app}/components/c"],
-            type: "Bundler",
+            type: "Bundler"
           },
           {
             name: "d",
             path: ["#{fixture_app}/components/d"],
-            type: "Bundler",
+            type: "Bundler"
           },
           {
             name: "f",
             path: ["#{fixture_app}/components/f"],
-            type: "Yarn",
+            type: "Yarn"
           },
           {
             name: "g",
             path: ["#{fixture_app}/components/g"],
-            type: "Yarn",
+            type: "Yarn"
           },
           {
             name: "h",
             path: ["#{fixture_app}/components/h"],
-            type: "Yarn & Bundler",
+            type: "Yarn & Bundler"
           },
           {
             name: "node_manifest",
             path: ["#{fixture_app}/node_manifest"],
-            type: "Yarn",
-          },
+            type: "Yarn"
+          }
         ]
       )
     end
@@ -143,8 +143,8 @@ RSpec.describe CobraCommander::Affected do
           {
             name: "f",
             path: ["#{fixture_app}/components/f"],
-            type: "Yarn",
-          },
+            type: "Yarn"
+          }
         ]
       )
     end
@@ -155,18 +155,18 @@ RSpec.describe CobraCommander::Affected do
           {
             name: "g",
             path: ["#{fixture_app}/components/g"],
-            type: "Yarn",
+            type: "Yarn"
           },
           {
             name: "h",
             path: ["#{fixture_app}/components/h"],
-            type: "Yarn & Bundler",
+            type: "Yarn & Bundler"
           },
           {
             name: "node_manifest",
             path: ["#{fixture_app}/node_manifest"],
-            type: "Yarn",
-          },
+            type: "Yarn"
+          }
         ]
       )
     end
@@ -176,7 +176,7 @@ RSpec.describe CobraCommander::Affected do
         "#{fixture_app}/components/f/test.sh",
         "#{fixture_app}/components/g/test.sh",
         "#{fixture_app}/components/h/test.sh",
-        "#{fixture_app}/node_manifest/test.sh",
+        "#{fixture_app}/node_manifest/test.sh"
       ]
     end
 

--- a/spec/cobra_commander/change_spec.rb
+++ b/spec/cobra_commander/change_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CobraCommander::Change do
         it "just lists single change" do
           allow_any_instance_of(CobraCommander::Change).to receive(:changes).and_return(
             [
-              "/change",
+              "/change"
             ]
           )
 
@@ -98,7 +98,7 @@ RSpec.describe CobraCommander::Change do
         it "lists change, affected component, and test" do
           allow_any_instance_of(CobraCommander::Change).to receive(:changes).and_return(
             [
-              "#{fixture_app}/components/a",
+              "#{fixture_app}/components/a"
             ]
           )
 
@@ -125,7 +125,7 @@ RSpec.describe CobraCommander::Change do
           allow_any_instance_of(CobraCommander::Change).to receive(:changes).and_return(
             [
               "#{fixture_app}/components/a",
-              "#{fixture_app}/components/b",
+              "#{fixture_app}/components/b"
             ]
           )
 
@@ -167,7 +167,7 @@ RSpec.describe CobraCommander::Change do
         it "lists changes, affected components, and tests" do
           allow_any_instance_of(CobraCommander::Change).to receive(:changes).and_return(
             [
-              "#{fixture_app}/components/e",
+              "#{fixture_app}/components/e"
             ]
           )
 

--- a/spec/cobra_commander/cli_spec.rb
+++ b/spec/cobra_commander/cli_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "cobra cli", type: :aruba do
 
     it "executes the given command a given component's ruby dependents" do
       run_command_and_stop("cobra exec --no-interactive -a #{fixture_app} --ruby --dependents b 'touch cobra-rocks'",
-                           fail_on_error: true)
+        fail_on_error: true)
 
       expect(components_affected).to match_array %w[a b c d h]
     end
@@ -67,21 +67,21 @@ RSpec.describe "cobra cli", type: :aruba do
 
     it "executes the given command a given component's js dependencies without self optionally" do
       run_command_and_stop("cobra exec --no-interactive -a #{fixture_app} --js --dependencies --no-self h 'touch cobra-rocks'",
-                           fail_on_error: true)
+        fail_on_error: true)
 
       expect(components_affected).to match_array %w[b e f]
     end
 
     it "executes the given command a given component's js dependencies including own component by default" do
       run_command_and_stop("cobra exec --no-interactive -a #{fixture_app} --js --dependencies h 'touch cobra-rocks'",
-                           fail_on_error: true)
+        fail_on_error: true)
 
       expect(components_affected).to match_array %w[b e f h]
     end
 
     it "executes the given command a given component's ruby dependencies" do
       run_command_and_stop("cobra exec --no-interactive -a #{fixture_app} --ruby --dependencies --no-self h 'echo \"hello from\" `pwd`'",
-                           fail_on_error: true)
+        fail_on_error: true)
 
       expect(last_command_output).to include("hello from #{fixture_app}/components/b")
     end

--- a/spec/cobra_commander/executor/concurrent_spec.rb
+++ b/spec/cobra_commander/executor/concurrent_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CobraCommander::Executor::Concurrent do
   end
 
   it "prints the status of each component" do
-    contexts = subject.exec("echo 'I am at' $PWD")
+    subject.exec("echo 'I am at' $PWD")
 
     expect(spin_output.string).to match(/\[DONE\](\e\[0m)? b/)
     expect(spin_output.string).to match(/\[DONE\](\e\[0m)? node_manifest/)

--- a/spec/cobra_commander/executor_spec.rb
+++ b/spec/cobra_commander/executor_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe CobraCommander::Executor do
   describe ".exec" do
     it "executes the given command with full output when its a single component" do
       contexts = CobraCommander::Executor.exec(components: [fixture_umbrella.find("a")],
-                                               command: "pwd", concurrency: 1, status_output: output)
+        command: "pwd", concurrency: 1, status_output: output)
 
       expect(contexts.map(&:output)).to match_array ["#{fixture_app}/components/a\n\n"]
     end
 
     it "executes the given command with status output only when multiple components are given" do
       CobraCommander::Executor.exec(components: fixture_umbrella.components, command: "pwd",
-                                    concurrency: 1, status_output: output)
+        concurrency: 1, status_output: output)
 
       expect(output.string).to_not include("[DONE]")
     end

--- a/spec/cobra_commander/output/graph_viz_spec.rb
+++ b/spec/cobra_commander/output/graph_viz_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe CobraCommander::Output::GraphViz do
           path: "a.path",
           dependencies: %w[a b],
           components: [
-            { name: "a", path: "a.path", dependencies: %w[b c] },
-            { name: "b", path: "b.path", dependencies: [] },
-            { name: "c", path: "c.path", dependencies: [] },
+            {name: "a", path: "a.path", dependencies: %w[b c]},
+            {name: "b", path: "b.path", dependencies: []},
+            {name: "c", path: "c.path", dependencies: []}
           ]
         )
       end

--- a/spec/cobra_commander/umbrella_spec.rb
+++ b/spec/cobra_commander/umbrella_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe CobraCommander::Umbrella do
         path: "/a/b/a.path",
         dependencies: %w[a b],
         components: [
-          { name: "x", path: "/a/b/c/x/x.path", dependencies: %w[b c] },
-          { name: "y", path: "/a/b/c/y/y.path", dependencies: [] },
-          { name: "z", path: "/a/b/c/z/z.path", dependencies: [] },
+          {name: "x", path: "/a/b/c/x/x.path", dependencies: %w[b c]},
+          {name: "y", path: "/a/b/c/y/y.path", dependencies: []},
+          {name: "z", path: "/a/b/c/z/z.path", dependencies: []}
         ]
       )
     end


### PR DESCRIPTION
Switch from rubocop to standardrb to align with community standards

- Switch rubocop by standardrb
- Update to standardrb format
- Update workflow to run standardrb
