### PR TITLE
Update bundler requirement to fix CI

### DIFF
--- a/gemfiles/bundler2.gemfile
+++ b/gemfiles/bundler2.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gemspec path: "../"
 
-gem "bundler", "2.3.5"
+gem "bundler", "~> 2.3.5"


### PR DESCRIPTION
Make the version requirement more loose so it will not break on minor bundler updates in the CI environment.
This also follow the same pattern we require for bundler v1.

Background:

CI is still breaking because of bundle v2 updates. See: https://github.com/powerhome/cobra_commander/actions/runs/1751150571