### PR TITLE
Multiple target components

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Allows a comma separated list of components on `cobra ls` and `cobra exec` instead of a single component
+
 ## Version 0.14.0 - 2021-11-24
 
 * Retain selection on Interactive Printer [#69](https://github.com/powerhome/cobra_commander/pull/69)

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,10 +28,10 @@ Or install it yourself as:
 ```bash
 Commands:
   cobra changes [--results=RESULTS] [--branch=BRANCH]  # Prints list of changed files
-  cobra exec [component] <command>                     # Executes the command in the context of a given component or set of components. If no component is given executes the command in all components.
+  cobra exec [components] <command>                     # Executes the command in the context of a given component or set of components. If no component is given executes the command in all components.
   cobra graph [component]                              # Outputs a graph of a given component or umbrella
   cobra help [COMMAND]                                 # Describe available commands or one specific command
-  cobra ls [component]                                 # Lists the components in the context of a given component or umbrella
+  cobra ls [components]                                 # Lists the components in the context of a given component or umbrella
   cobra tree [component]                               # Prints the dependency tree of a given component or umbrella
   cobra version                                        # Prints version
 
@@ -65,7 +65,9 @@ Prints list of changed files
 
 ```sh
 Usage:
-  cobra exec [component] <command>
+  cobra exec [components] <command>
+
+[components] is all components by default, or a comma separated list of component names (no spaces between)
 
 Options:
       [--dependencies], [--no-dependencies]  # Run the command on each dependency of a given component
@@ -99,7 +101,9 @@ Outputs a graph of a given component or umbrella
 
 ```sh
 Usage:
-  cobra ls [component]
+  cobra ls [components]
+
+[components] is all components by default, or a comma separated list of component names (no spaces between)
 
 Options:
   -d, [--dependencies], [--no-dependencies]  # Run the command on each dependency of a given component

--- a/lib/cobra_commander/cli/filters.rb
+++ b/lib/cobra_commander/cli/filters.rb
@@ -31,12 +31,15 @@ module CobraCommander
     def components_filtered(component_names)
       return umbrella.components unless component_names
 
-      component_names.split(",").each_with_object(Set.new) do |component_name, set|
-        component = find_component(component_name)
-        set.add component if options.self
-        set.merge component.deep_dependencies if options.dependencies
-        set.merge component.deep_dependents if options.dependents
-      end
+      component_names.split(",")
+                     .each_with_object(Set.new) { |name, set| filter_component(name, set) }
+    end
+
+    def filter_component(component_name, set)
+      component = find_component(component_name)
+      set.add component if options.self
+      set.merge component.deep_dependencies if options.dependencies
+      set.merge component.deep_dependents if options.dependents
     end
   end
 end

--- a/lib/cobra_commander/cli/filters.rb
+++ b/lib/cobra_commander/cli/filters.rb
@@ -31,12 +31,11 @@ module CobraCommander
     def components_filtered(component_names)
       return umbrella.components unless component_names
 
-      component_names.split(",").flat_map do |component_name|
+      component_names.split(",").each_with_object(Set.new) do |component_name, set|
         component = find_component(component_name)
-        components = options.self ? [component] : []
-        components.concat component.deep_dependencies if options.dependencies
-        components.concat component.deep_dependents if options.dependents
-        components
+        set.add component if options.self
+        set.merge component.deep_dependencies if options.dependencies
+        set.merge component.deep_dependents if options.dependents
       end
     end
   end

--- a/lib/cobra_commander/cli/filters.rb
+++ b/lib/cobra_commander/cli/filters.rb
@@ -28,14 +28,16 @@ module CobraCommander
       []
     end
 
-    def components_filtered(component_name)
-      return umbrella.components unless component_name
+    def components_filtered(component_names)
+      return umbrella.components unless component_names
 
-      component = find_component(component_name)
-      components = options.self ? [component] : []
-      components.concat component.deep_dependencies if options.dependencies
-      components.concat component.deep_dependents if options.dependents
-      components
+      component_names.split(",").flat_map do |component_name|
+        component = find_component(component_name)
+        components = options.self ? [component] : []
+        components.concat component.deep_dependencies if options.dependencies
+        components.concat component.deep_dependents if options.dependents
+        components
+      end
     end
   end
 end

--- a/spec/cobra_commander/cli_spec.rb
+++ b/spec/cobra_commander/cli_spec.rb
@@ -291,10 +291,22 @@ RSpec.describe "cobra cli", type: :aruba do
       expect(last_command_output).to match(/Component node_manifeast not found, maybe node_manifest, one of "cobra ls"/)
     end
 
+    it "suggests with DidYouMean when one of the list does not exist", if: RUBY_2_7 do
+      run_command_and_stop("cobra ls -a #{fixture_app} node_manifeast,a,b", fail_on_error: false)
+
+      expect(last_command_output).to match(/Component node_manifeast not found, maybe node_manifest, one of "cobra ls"/)
+    end
+
     it "has a default suggestion when there isn't DidYouMean", unless: RUBY_2_7 do
-      run_command_and_stop("cobra ls -a #{fixture_app} node_manifeast", fail_on_error: false)
+      run_command_and_stop("cobra ls -a #{fixture_app} node_manifest", fail_on_error: false)
 
       expect(last_command_output).to match(/Component node_manifeast not found, maybe one of "cobra ls"/)
+    end
+
+    it "lists a comma separated list of components" do
+      run_command_and_stop("cobra ls -a #{fixture_app} node_manifest,a,b", fail_on_error: false)
+
+      expect(last_command_output.strip.split("\n")).to match(%w[a b node_manifest])
     end
 
     describe "cobra ls component --dependents" do

--- a/spec/cobra_commander/cli_spec.rb
+++ b/spec/cobra_commander/cli_spec.rb
@@ -309,6 +309,12 @@ RSpec.describe "cobra cli", type: :aruba do
       expect(last_command_output.strip.split("\n")).to match(%w[a b node_manifest])
     end
 
+    it "lists components uniquely" do
+      run_command_and_stop("cobra ls -a #{fixture_app} node_manifest,a,a,b,b", fail_on_error: false)
+
+      expect(last_command_output.strip.split("\n")).to match(%w[a b node_manifest])
+    end
+
     describe "cobra ls component --dependents" do
       it "lists a component's direct dependents" do
         run_command_and_stop("cobra ls -a #{fixture_app} --dependents --no-self node_manifest", fail_on_error: true)


### PR DESCRIPTION
Allows multiple components to be targeted on `cobra ls` and `cobra exec`.

I.e.:

Execute the same command on a, b, and c:

`cobra exec a,b,c "echo hello"`

Execute the same command on a and b, and all its dependents:

`cobra exec --dependents a,b,c "echo hello"`