### PR TITLE
Remove unused/broken methods from CobraCommander API

### DIFF
--- a/lib/cobra_commander.rb
+++ b/lib/cobra_commander.rb
@@ -17,12 +17,4 @@ module CobraCommander
     umbrella.add_source(:bundler, Dependencies::Bundler.new(root_path)) unless yarn
     umbrella
   end
-
-  def self.umbrella_tree(path)
-    CalculatedComponentTree.new(UMBRELLA_APP_NAME, path)
-  end
-
-  def self.tree_from_cache(cache_file)
-    CachedComponentTree.from_cache_file(cache_file)
-  end
 end


### PR DESCRIPTION
Remove unused/broken methods from CobraCommander API. These methods refer to unexisting classes that are no longer necessary (due to performance improvements) and were removed long ago.