### PR TITLE
Add depends_on criteria for cobra commands

### DIFF
--- a/cobra_commander/lib/cobra_commander/executor/package_criteria.rb
+++ b/cobra_commander/lib/cobra_commander/executor/package_criteria.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative "./job"
+require_relative "./package_criteria"
+
+module CobraCommander
+  module Executor
+    module PackageCriteria
+      def match_criteria?(package, criteria)
+        criteria.all? do |criteria_key, criteria_value|
+          criteria_method = "_match_#{criteria_key}?"
+          !respond_to?(criteria_method, true) || send(criteria_method, package, criteria_value)
+        end
+      end
+
+      def _match_depends_on?(package, packages)
+        (Array(packages) - package.dependencies).empty?
+      end
+    end
+  end
+end

--- a/docs/README.md
+++ b/docs/README.md
@@ -155,7 +155,45 @@ Options:
 Prints the dependency tree of a given component or umbrella
 ```
 
-### Releasing
+## cobra.yml
+
+### Cobra Commands
+
+You can create pre-defined commands to be run in multiple components and packages with `cobra cmd`. An example configuration looks like:
+
+```yaml
+sources:
+  :ruby:
+    commands:
+      deps: bundle install
+  :js:
+    commands:
+      deps: yarn install
+```
+
+Then running `cobra cmd deps` will run `bundle install` in all ruby packages, and `yarn install` in all JS packages. It will run both commands when the component has both packages.
+
+#### Conditional commands
+
+You can also conditionally disable commands with `if`:
+
+```yaml
+sources:
+  :ruby:
+    commands:
+      deps: bundle install
+      database:
+        if:
+          depends_on: database
+        run: rake db:refresh
+  :js:
+    commands:
+      deps: yarn install
+```
+
+Then running `cobra cmd database` will run `rake db:refresh` in all ruby that depends on the `database` package, and will skip on all other packages.
+
+## Releasing
 
 To release a new version, create a PR updating the version number in `version.rb`, close the version changes in CHANGELOG.md, and create a version tag in master matching the package being released (i.e.: v1.1.1-cobra_commander).
 


### PR DESCRIPTION
Allow a job to be run conditionally:

I.e.:

```yaml
sources:
  :ruby:
    commands:
      database:
        if:
          depends_on: database
        run: build database
```
