### PR TITLE
Cobra cmd sequential commands

### DIFF
--- a/cobra_commander/lib/cobra_commander/executor/command.rb
+++ b/cobra_commander/lib/cobra_commander/executor/command.rb
@@ -12,18 +12,30 @@ module CobraCommander
       SKIP_UNEXISTING = "Command %s does not exist. Check your cobra.yml for existing commands in %s."
       SKIP_CRITERIA = "Package %s does not match criteria."
 
-      # Executes the given script in all Components.
-      #
-      # If a component has two packages in the same path, the script will run only once.
+      # Builds the given commands in all packages of all components.
       #
       # @param components [Enumerable<CobraCommander::Component>] the target components
-      # @param script [String] shell script to run from the directories of the component's packages
-      # @param workers [Integer] number of workers processing the job queue
-      # @return [CobraCommander::Executor::Execution]
-      # @see .execute
+      # @param command [String] shell script to run from the directories of the component's packages
+      # @return [Array<CobraCommander::Executor::Command>]
       def self.for(components, command)
         components.flat_map(&:packages).map do |package|
           new(package, command)
+        end
+      end
+
+      # Calls the commands sequentially, stopping ony if an :error happens.
+      #
+      # If one of the commands skips, the result will be :success.
+      #
+      # @param commands [Enumerable<CobraCommander::Component>] the target components
+      # @return [Array<CobraCommander::Executor::Command>]
+      # @see CobraCommander::Executor::Job
+      def self.join(commands)
+        commands.lazy.map(&:call).reduce do |(_, prev_output), (result, output)|
+          new_output = [prev_output&.strip, output&.strip].join("\n")
+          return [:error, new_output] if result == :error
+
+          [:success, new_output]
         end
       end
 
@@ -36,19 +48,27 @@ module CobraCommander
         "#{@package.name} (#{@package.key})"
       end
 
+      # @see CobraCommander::Executor::Job
       def call
         command = @package.source.config&.dig("commands", @command)
         case command
-        when Hash then run_with_criteria command
+        when Array then run_multiple(@package, command)
+        when Hash then run_with_criteria(command)
         when nil then skip(format(SKIP_UNEXISTING, @command, @package.key))
-        else run_script command, @package.path
+        else run_script(command, @package.path)
         end
       end
+
+    private
 
       def run_with_criteria(command)
         return skip(format(SKIP_CRITERIA, @package.name)) unless match_criteria?(@package, command.fetch("if", {}))
 
-        run_script command["run"], @package.path
+        run_script(command["run"], @package.path)
+      end
+
+      def run_multiple(package, commands)
+        Command.join(commands.map { |command| Command.new(package, command) })
       end
     end
   end

--- a/cobra_commander/lib/cobra_commander/executor/script.rb
+++ b/cobra_commander/lib/cobra_commander/executor/script.rb
@@ -36,6 +36,7 @@ module CobraCommander
         @package.name
       end
 
+      # @see CobraCommander::Executor::Job
       def call
         run_script @script, @package.path
       end

--- a/cobra_commander/spec/cobra_commander/executor/command_spec.rb
+++ b/cobra_commander/spec/cobra_commander/executor/command_spec.rb
@@ -66,4 +66,68 @@ RSpec.describe CobraCommander::Executor::Command do
       end
     end
   end
+
+  describe "sequential execution" do
+    let(:will_skip) do
+      {
+        "if" => { "depends_on" => ["i_dont_exist"] },
+        "run" => "doesn't matter wont run",
+      }
+    end
+    let(:failing_command) { "i just fail" }
+    let(:command_rofl) { "echo 'rofl'" }
+    let(:command_lol) { "echo 'lol'" }
+    let(:source) do
+      double("le source", key: "le",
+                          config: {
+                            "commands" => {
+                              "skp" => will_skip,
+                              "fail" => failing_command,
+                              "rofl" => command_rofl,
+                              "lol" => command_lol,
+                              "lol_and_fail" => %w[lol fail rofl],
+                              "ltc" => %w[lol rofl],
+                              "ltc_lol" => %w[ltc lol],
+                              "lol_skip_rolf" => %w[lol skp rofl],
+                              "lol_skip" => %w[lol skp],
+                            },
+                          })
+    end
+    let(:package) { CobraCommander::Package.new(source, path: "./", dependencies: [], name: "management") }
+
+    it "can run other commands in a sequential order" do
+      result, output = run_command(package, "ltc")
+
+      expect(result).to be :success
+      expect(output).to eql "lol\nrofl"
+    end
+
+    it "stops when one command fails" do
+      result, output = run_command(package, "lol_and_fail")
+
+      expect(result).to be :error
+      expect(output).to eql "lol\nsh: i: command not found"
+    end
+
+    it "allows nested dependency" do
+      result, output = run_command(package, "ltc_lol")
+
+      expect(result).to be :success
+      expect(output).to eql "lol\nrofl\nlol"
+    end
+
+    it "skips conditional commands" do
+      result, output = run_command(package, "lol_skip_rolf")
+
+      expect(result).to be :success
+      expect(output).to eql "lol\nPackage management does not match criteria.\nrofl"
+    end
+
+    it "succeeds when last command skips" do
+      result, output = run_command(package, "lol_skip")
+
+      expect(result).to be :success
+      expect(output).to eql "lol\nPackage management does not match criteria."
+    end
+  end
 end

--- a/docs/README.md
+++ b/docs/README.md
@@ -193,6 +193,36 @@ sources:
 
 Then running `cobra cmd database` will run `rake db:refresh` in all ruby that depends on the `database` package, and will skip on all other packages.
 
+#### Sequential commands
+
+Sometimes a specific order of commands has to be run to achieve something, that can be done with sequential commands like this:
+
+```yaml
+sources:
+  :ruby:
+    commands:
+      deps: bundle install
+      database:
+        if:
+          depends_on: database
+        run: rake db:refresh
+      test: rake test
+      ci:
+        - deps
+        - database
+        - test
+  :js:
+    commands:
+      deps: yarn install
+      ci:
+        - deps
+        - test
+```
+
+Then running `cobra cmd ci` will run "deps", then "database", then "test" in all ruby packages. On packages that don't depend on `database` the database job will skip. On JS packages it will run "deps" and then "test".
+
+If any error occur, the execution stops and returns an that job is classified as error.
+
 ## Releasing
 
 To release a new version, create a PR updating the version number in `version.rb`, close the version changes in CHANGELOG.md, and create a version tag in master matching the package being released (i.e.: v1.1.1-cobra_commander).


### PR DESCRIPTION
Sometimes a specific order of commands has to be run to achieve something, that can be done with sequential commands like this:

```yaml
sources:
  :ruby:
    commands:
      deps: bundle install
      database:
        if:
          depends_on: database
        run: rake db:refresh
      test: rake test
      ci:
        - deps
        - database
        - test
  :js:
    commands:
      deps: yarn install
      ci:
        - deps
        - test
```

Then running `cobra cmd ci` will run "deps", then "database", then "test" in all ruby packages. On packages that don't depend on `database` the database job will skip. On JS packages it will run "deps" and then "test".

- Add sequential commands execution
- Add documentation
