### PR TITLE
Fix umbrella resolve

### DIFF
--- a/cobra_commander/lib/cobra_commander/umbrella.rb
+++ b/cobra_commander/lib/cobra_commander/umbrella.rb
@@ -48,7 +48,7 @@ module CobraCommander
     def resolve(path)
       components.find do |component|
         component.root_paths.any? do |component_path|
-          path.to_s.start_with?(component_path.cleanpath.to_s)
+          component_path.eql?(path) || path.to_s.start_with?("#{component_path.cleanpath}/")
         end
       end
     end

--- a/cobra_commander/spec/cobra_commander/umbrella_spec.rb
+++ b/cobra_commander/spec/cobra_commander/umbrella_spec.rb
@@ -41,5 +41,11 @@ RSpec.describe CobraCommander::Umbrella do
     it "is nil when no component was found" do
       expect(subject.resolve("/a/b/c/lol")).to be_nil
     end
+
+    it "resolves names that start similarly" do
+      finance_path = fixture_file_path("app/finance")
+
+      expect(subject.resolve("#{finance_path}_models")).to be_nil
+    end
   end
 end


### PR DESCRIPTION
umbrella#resolve can't currently resolve when a package path partially matches the path of another.