### PR TITLE
Fix Umbrella resolve when resolving relative paths

### DIFF
--- a/cobra_commander/lib/cobra_commander/affected.rb
+++ b/cobra_commander/lib/cobra_commander/affected.rb
@@ -19,7 +19,7 @@ module CobraCommander
     end
 
     def scripts
-      @scripts ||= paths.map { |path| File.join(path, "test.sh") }
+      @scripts ||= paths.map { |path| path.join("test.sh") }
     end
 
     def directly

--- a/cobra_commander/lib/cobra_commander/umbrella.rb
+++ b/cobra_commander/lib/cobra_commander/umbrella.rb
@@ -48,7 +48,7 @@ module CobraCommander
     def resolve(path)
       components.find do |component|
         component.root_paths.any? do |component_path|
-          component_path.eql?(Pathname.new(path)) || path.to_s.start_with?("#{component_path.cleanpath}/")
+          component_path.eql?(path) || path.expand_path.to_s.start_with?("#{component_path.expand_path}/")
         end
       end
     end

--- a/cobra_commander/spec/cobra_commander/affected_spec.rb
+++ b/cobra_commander/spec/cobra_commander/affected_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CobraCommander::Affected do
 
   context "with change to top level dependency" do
     let(:with_change_to_hr) do
-      CobraCommander::Affected.new(umbrella, [umbrella.path.join("hr", "index.html").to_s])
+      CobraCommander::Affected.new(umbrella, [umbrella.path.join("hr", "index.html")])
     end
 
     it "correctly reports directly affected components" do
@@ -44,7 +44,7 @@ RSpec.describe CobraCommander::Affected do
     end
 
     it "correctly reports test scripts" do
-      expect(with_change_to_hr.scripts).to eq([umbrella.path.join("hr", "test.sh").to_s])
+      expect(with_change_to_hr.scripts).to eq([umbrella.path.join("hr", "test.sh")])
     end
 
     it "correctly reports component names" do
@@ -54,7 +54,7 @@ RSpec.describe CobraCommander::Affected do
 
   context "with change to lower level dependency" do
     let(:with_change_to_directory) do
-      CobraCommander::Affected.new(umbrella, [umbrella.path.join("directory", "index.html").to_s])
+      CobraCommander::Affected.new(umbrella, [umbrella.path.join("directory", "index.html")])
     end
 
     it "correctly reports directly affected components" do
@@ -75,10 +75,10 @@ RSpec.describe CobraCommander::Affected do
 
     it "correctly reports test scripts" do
       expect(with_change_to_directory.scripts).to match_array [
-        umbrella.path.join("directory", "test.sh").to_s,
-        umbrella.path.join("finance", "test.sh").to_s,
-        umbrella.path.join("hr", "test.sh").to_s,
-        umbrella.path.join("sales", "test.sh").to_s,
+        umbrella.path.join("directory", "test.sh"),
+        umbrella.path.join("finance", "test.sh"),
+        umbrella.path.join("hr", "test.sh"),
+        umbrella.path.join("sales", "test.sh"),
       ]
     end
 
@@ -89,7 +89,7 @@ RSpec.describe CobraCommander::Affected do
 
   context "with change to lowest level dependency" do
     let(:with_change_to_auth) do
-      CobraCommander::Affected.new(umbrella, [umbrella.path.join("auth", "index.js").to_s])
+      CobraCommander::Affected.new(umbrella, [umbrella.path.join("auth", "index.js")])
     end
 
     it "correctly reports directly affected components" do
@@ -112,11 +112,11 @@ RSpec.describe CobraCommander::Affected do
 
     it "correctly reports test scripts" do
       expect(with_change_to_auth.scripts).to match_array [
-        umbrella.path.join("auth", "test.sh").to_s,
-        umbrella.path.join("directory", "test.sh").to_s,
-        umbrella.path.join("finance", "test.sh").to_s,
-        umbrella.path.join("hr", "test.sh").to_s,
-        umbrella.path.join("sales", "test.sh").to_s,
+        umbrella.path.join("auth", "test.sh"),
+        umbrella.path.join("directory", "test.sh"),
+        umbrella.path.join("finance", "test.sh"),
+        umbrella.path.join("hr", "test.sh"),
+        umbrella.path.join("sales", "test.sh"),
       ]
     end
 

--- a/cobra_commander/spec/cobra_commander/cli/output/change_spec.rb
+++ b/cobra_commander/spec/cobra_commander/cli/output/change_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CobraCommander::CLI::Output::Change do
       context "with a change inside a component" do
         it "lists change, affected component, and test" do
           change = CobraCommander::CLI::Output::Change.new(umbrella, "json", "master",
-                                                           changes: [umbrella.path.join("hr", "index.html").to_s])
+                                                           changes: [umbrella.path.join("hr", "index.html")])
 
           expect { change.run! }.to output(<<~OUTPUT
             {"changed_files":["#{umbrella.path.join('hr', 'index.html')}"],"directly_affected_components":[{"name":"hr","path":["#{umbrella.path.join('hr')}"],"type":["stub"]}],"transitively_affected_components":[],"test_scripts":["#{umbrella.path.join('hr', 'test.sh')}"],"component_names":["hr"],"languages":["stub"]}
@@ -38,7 +38,7 @@ RSpec.describe CobraCommander::CLI::Output::Change do
       context "with change inside a very utilized component" do
         it "lists changes, affected components, and tests" do
           change = CobraCommander::CLI::Output::Change.new(umbrella, "json", "master",
-                                                           changes: [umbrella.path.join("auth", "index.html").to_s])
+                                                           changes: [umbrella.path.join("auth", "index.html")])
 
           expect { change.run! }.to output(<<~OUTPUT
             {"changed_files":["#{umbrella.path.join('auth', 'index.html')}"],"directly_affected_components":[{"name":"auth","path":["#{umbrella.path.join('auth')}"],"type":["stub"]}],"transitively_affected_components":[{"name":"directory","path":["#{umbrella.path.join('directory')}"],"type":["stub"]},{"name":"finance","path":["#{umbrella.path.join('finance')}"],"type":["stub"]},{"name":"hr","path":["#{umbrella.path.join('hr')}"],"type":["stub"]},{"name":"sales","path":["#{umbrella.path.join('sales')}"],"type":["stub"]}],"test_scripts":["#{umbrella.path.join('auth', 'test.sh')}","#{umbrella.path.join('directory', 'test.sh')}","#{umbrella.path.join('finance', 'test.sh')}","#{umbrella.path.join('hr', 'test.sh')}","#{umbrella.path.join('sales', 'test.sh')}"],"component_names":["auth","directory","finance","hr","sales"],"languages":["stub"]}
@@ -68,7 +68,8 @@ RSpec.describe CobraCommander::CLI::Output::Change do
 
       context "with a change outside a component" do
         it "just lists single change" do
-          change = CobraCommander::CLI::Output::Change.new(umbrella, "full", "master", changes: ["/change"])
+          change = CobraCommander::CLI::Output::Change.new(umbrella, "full", "master",
+                                                           changes: [Pathname.new("/change")])
 
           expect { change.run! }.to output(<<~OUTPUT
             <<< Changes since last commit on master >>>
@@ -87,7 +88,7 @@ RSpec.describe CobraCommander::CLI::Output::Change do
       context "with a change inside a component" do
         it "lists change, affected component, and test" do
           change = CobraCommander::CLI::Output::Change.new(umbrella, "full", "master",
-                                                           changes: [umbrella.path.join("hr", "index.html").to_s])
+                                                           changes: [umbrella.path.join("hr", "index.html")])
 
           expect { change.run! }.to output(<<~OUTPUT
             <<< Changes since last commit on master >>>
@@ -109,7 +110,7 @@ RSpec.describe CobraCommander::CLI::Output::Change do
         it "lists changes, affected components, and tests" do
           change = CobraCommander::CLI::Output::Change.new(
             umbrella, "full", "master",
-            changes: [umbrella.path.join("directory", "index.js").to_s, umbrella.path.join("sales", "index.js").to_s]
+            changes: [umbrella.path.join("directory", "index.js"), umbrella.path.join("sales", "index.js")]
           )
 
           expect { change.run! }.to output(<<~OUTPUT
@@ -139,7 +140,7 @@ RSpec.describe CobraCommander::CLI::Output::Change do
       context "with change inside a very utilized component" do
         it "lists changes, affected components, and tests" do
           change = CobraCommander::CLI::Output::Change.new(umbrella, "full", "master",
-                                                           changes: [umbrella.path.join("auth", "index.html").to_s])
+                                                           changes: [umbrella.path.join("auth", "index.html")])
 
           expect { change.run! }.to output(<<~OUTPUT
             <<< Changes since last commit on master >>>

--- a/cobra_commander/spec/cobra_commander/umbrella_spec.rb
+++ b/cobra_commander/spec/cobra_commander/umbrella_spec.rb
@@ -39,14 +39,13 @@ RSpec.describe CobraCommander::Umbrella do
     end
 
     it "is nil when no component was found" do
-      expect(subject.resolve("/a/b/c/lol")).to be_nil
+      expect(subject.resolve(Pathname.new("/a/b/c/lol"))).to be_nil
     end
 
     it "resolves names that start similarly" do
       finance_models_path = fixture_file_path("app/finance_models")
 
       expect(subject.resolve(finance_models_path).name).to eql "finance_models"
-      expect(subject.resolve(finance_models_path.to_s).name).to eql "finance_models"
     end
   end
 end


### PR DESCRIPTION
`Umbrella#resolve` was unable to resolve a path relative to the project, this PR switches the resolve method to only accept Pathname, and therefore it can find the realpath of the file.
