### PR TITLE
Cleanup cobra changes

### DIFF
--- a/cobra_commander/docs/CHANGELOG.md
+++ b/cobra_commander/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+* New Executor by @xjunior in [#104](https://github.com/powerhome/cobra_commander/pull/104)
+* Cleanup cobra changes by @xjunior in [#105](https://github.com/powerhome/cobra_commander/pull/105)
+
 ## Version 1.0.1 - 2023-01-05
 
 * Fix Umbrella#resolve unable to resolve a path relative to the project @xjunior [#103](https://github.com/powerhome/cobra_commander/pull/103)

--- a/cobra_commander/lib/cobra_commander/cli.rb
+++ b/cobra_commander/lib/cobra_commander/cli.rb
@@ -92,10 +92,9 @@ module CobraCommander
     end
 
     desc "changes [--results=RESULTS] [--branch=BRANCH]", "Prints list of changed files"
-    method_option :results, default: "test", aliases: "-r", desc: "Accepts test, full, name or json"
     method_option :branch, default: "master", aliases: "-b", desc: "Specified target to calculate against"
     def changes
-      Output::Change.new(umbrella, options.results, options.branch).run!
+      Output::Change.new(umbrella, options.branch).run!
     end
 
   private

--- a/cobra_commander/lib/cobra_commander/cli/filters.rb
+++ b/cobra_commander/lib/cobra_commander/cli/filters.rb
@@ -29,7 +29,7 @@ module CobraCommander
 
     def affected_by_changes(origin_branch)
       changes = GitChanged.new(umbrella.path, origin_branch)
-      Affected.new(umbrella, changes).all
+      Affected.new(umbrella, changes).to_a
     end
 
     def filter_component(component_name)

--- a/cobra_commander/lib/cobra_commander/cli/output/change.rb
+++ b/cobra_commander/lib/cobra_commander/cli/output/change.rb
@@ -6,27 +6,19 @@ require "cobra_commander/affected"
 module CobraCommander
   class CLI
     module Output
-      # Calculates and prints affected components & files
       class Change
-        InvalidSelectionError = Class.new(StandardError)
-
-        def initialize(umbrella, oformat, branch, changes: nil)
-          @format = oformat
+        def initialize(umbrella, branch, changes: nil)
           @branch = branch
           @umbrella = umbrella
           @changes = changes || GitChanged.new(umbrella.path, branch)
         end
 
         def run!
-          assert_valid_result_choice
-          if selected_format?("json")
-            puts affected.to_json
-          else
-            show_full if selected_format?("full")
-            tests_to_run
-          end
-        rescue GitChanged::InvalidSelectionError => e
-          puts e.message
+          print_changes_since_last_commit
+          puts
+          print_directly_affected_components
+          puts
+          print_transitively_affected_components
         end
 
       private
@@ -35,55 +27,23 @@ module CobraCommander
           @affected ||= Affected.new(@umbrella, @changes)
         end
 
-        def show_full
-          changes_since_last_commit
-          directly_affected_components
-          transitively_affected_components
-        end
-
-        def assert_valid_result_choice
-          return if %w[test full name json].include?(@format)
-
-          raise InvalidSelectionError, "--results must be 'test', 'full', 'name' or 'json'"
-        end
-
-        def selected_format?(result)
-          @format == result
-        end
-
-        def changes_since_last_commit
+        def print_changes_since_last_commit
           puts "<<< Changes since last commit on #{@branch} >>>"
           puts(*@changes) if @changes.any?
-          puts blank_line
         end
 
-        def directly_affected_components
+        def print_directly_affected_components
           puts "<<< Directly affected components >>>"
-          affected.directly.each { |component| puts display(component) }
-          puts blank_line
+          affected.directly.each { |component| display(component) }
         end
 
-        def transitively_affected_components
+        def print_transitively_affected_components
           puts "<<< Transitively affected components >>>"
-          affected.transitively.each { |component| puts display(component) }
-          puts blank_line
-        end
-
-        def tests_to_run
-          puts "<<< Test scripts to run >>>" if selected_format?("full")
-          if selected_format?("name")
-            affected.names.each { |component_name| puts component_name }
-          else
-            affected.scripts.each { |component_script| puts component_script }
-          end
+          affected.transitively.each { |component| display(component) }
         end
 
         def display(component)
-          "#{component.name} - #{component.packages.map(&:key).map(&:to_s).map(&:capitalize).join(' & ')}"
-        end
-
-        def blank_line
-          ""
+          puts "#{component.name} - #{component.packages.map(&:key).map(&:to_s).map(&:capitalize).join(' & ')}"
         end
       end
     end

--- a/cobra_commander/spec/cobra_commander/affected_spec.rb
+++ b/cobra_commander/spec/cobra_commander/affected_spec.rb
@@ -22,10 +22,6 @@ RSpec.describe CobraCommander::Affected do
     it "reports no transitiely affected components" do
       expect(no_changes.transitively).to eq []
     end
-
-    it "reports no testing needs" do
-      expect(no_changes.scripts).to eq []
-    end
   end
 
   context "with change to top level dependency" do
@@ -41,14 +37,6 @@ RSpec.describe CobraCommander::Affected do
 
     it "correctly reports directly affected components" do
       expect(with_change_to_hr.transitively).to eq []
-    end
-
-    it "correctly reports test scripts" do
-      expect(with_change_to_hr.scripts).to eq([umbrella.path.join("hr", "test.sh")])
-    end
-
-    it "correctly reports component names" do
-      expect(with_change_to_hr.names).to eq(["hr"])
     end
   end
 
@@ -73,17 +61,8 @@ RSpec.describe CobraCommander::Affected do
       expect(with_change_to_directory.transitively[2].packages.map(&:key)).to eql %i[stub]
     end
 
-    it "correctly reports test scripts" do
-      expect(with_change_to_directory.scripts).to match_array [
-        umbrella.path.join("directory", "test.sh"),
-        umbrella.path.join("finance", "test.sh"),
-        umbrella.path.join("hr", "test.sh"),
-        umbrella.path.join("sales", "test.sh"),
-      ]
-    end
-
     it "correctly reports component names" do
-      expect(with_change_to_directory.names).to match_array %w[directory finance hr sales]
+      expect(with_change_to_directory.map(&:name)).to match_array %w[directory finance hr sales]
     end
   end
 
@@ -110,18 +89,8 @@ RSpec.describe CobraCommander::Affected do
       expect(with_change_to_auth.transitively[3].packages.map(&:key)).to eql %i[stub]
     end
 
-    it "correctly reports test scripts" do
-      expect(with_change_to_auth.scripts).to match_array [
-        umbrella.path.join("auth", "test.sh"),
-        umbrella.path.join("directory", "test.sh"),
-        umbrella.path.join("finance", "test.sh"),
-        umbrella.path.join("hr", "test.sh"),
-        umbrella.path.join("sales", "test.sh"),
-      ]
-    end
-
     it "correctly reports component names" do
-      expect(with_change_to_auth.names).to match_array %w[auth directory finance hr sales]
+      expect(with_change_to_auth.map(&:name)).to match_array %w[auth directory finance hr sales]
     end
   end
 end

--- a/cobra_commander/spec/cobra_commander/cli/output/change_spec.rb
+++ b/cobra_commander/spec/cobra_commander/cli/output/change_spec.rb
@@ -7,51 +7,14 @@ RSpec.describe CobraCommander::CLI::Output::Change do
   let(:umbrella) { stub_umbrella("app") }
 
   it "successfully instantiates" do
-    expect(CobraCommander::CLI::Output::Change.new(umbrella, "full", "master")).to be_truthy
+    expect(CobraCommander::CLI::Output::Change.new(umbrella, "master")).to be_truthy
   end
 
   describe ".run!" do
-    context "with json results" do
-      context "with no changes" do
-        it "lists no files" do
-          changes = CobraCommander::CLI::Output::Change.new(umbrella, "json", "master", changes: [])
-
-          expect { changes.run! }.to output(<<~OUTPUT
-            {"changed_files":[],"directly_affected_components":[],"transitively_affected_components":[],"test_scripts":[],"component_names":[],"languages":[]}
-          OUTPUT
-                                           ).to_stdout
-        end
-      end
-
-      context "with a change inside a component" do
-        it "lists change, affected component, and test" do
-          change = CobraCommander::CLI::Output::Change.new(umbrella, "json", "master",
-                                                           changes: [umbrella.path.join("hr", "index.html")])
-
-          expect { change.run! }.to output(<<~OUTPUT
-            {"changed_files":["#{umbrella.path.join('hr', 'index.html')}"],"directly_affected_components":[{"name":"hr","path":["#{umbrella.path.join('hr')}"],"type":["stub"]}],"transitively_affected_components":[],"test_scripts":["#{umbrella.path.join('hr', 'test.sh')}"],"component_names":["hr"],"languages":["stub"]}
-          OUTPUT
-                                          ).to_stdout
-        end
-      end
-
-      context "with change inside a very utilized component" do
-        it "lists changes, affected components, and tests" do
-          change = CobraCommander::CLI::Output::Change.new(umbrella, "json", "master",
-                                                           changes: [umbrella.path.join("auth", "index.html")])
-
-          expect { change.run! }.to output(<<~OUTPUT
-            {"changed_files":["#{umbrella.path.join('auth', 'index.html')}"],"directly_affected_components":[{"name":"auth","path":["#{umbrella.path.join('auth')}"],"type":["stub"]}],"transitively_affected_components":[{"name":"directory","path":["#{umbrella.path.join('directory')}"],"type":["stub"]},{"name":"finance","path":["#{umbrella.path.join('finance')}"],"type":["stub"]},{"name":"hr","path":["#{umbrella.path.join('hr')}"],"type":["stub"]},{"name":"sales","path":["#{umbrella.path.join('sales')}"],"type":["stub"]}],"test_scripts":["#{umbrella.path.join('auth', 'test.sh')}","#{umbrella.path.join('directory', 'test.sh')}","#{umbrella.path.join('finance', 'test.sh')}","#{umbrella.path.join('hr', 'test.sh')}","#{umbrella.path.join('sales', 'test.sh')}"],"component_names":["auth","directory","finance","hr","sales"],"languages":["stub"]}
-          OUTPUT
-                                          ).to_stdout
-        end
-      end
-    end
-
     context "with full results" do
       context "with no changes" do
         it "lists no files" do
-          changes = CobraCommander::CLI::Output::Change.new(umbrella, "full", "master", changes: [])
+          changes = CobraCommander::CLI::Output::Change.new(umbrella, "master", changes: [])
 
           expect { changes.run! }.to output(<<~OUTPUT
             <<< Changes since last commit on master >>>
@@ -59,8 +22,6 @@ RSpec.describe CobraCommander::CLI::Output::Change do
             <<< Directly affected components >>>
 
             <<< Transitively affected components >>>
-
-            <<< Test scripts to run >>>
           OUTPUT
                                            ).to_stdout
         end
@@ -68,7 +29,7 @@ RSpec.describe CobraCommander::CLI::Output::Change do
 
       context "with a change outside a component" do
         it "just lists single change" do
-          change = CobraCommander::CLI::Output::Change.new(umbrella, "full", "master",
+          change = CobraCommander::CLI::Output::Change.new(umbrella, "master",
                                                            changes: [Pathname.new("/change")])
 
           expect { change.run! }.to output(<<~OUTPUT
@@ -78,8 +39,6 @@ RSpec.describe CobraCommander::CLI::Output::Change do
             <<< Directly affected components >>>
 
             <<< Transitively affected components >>>
-
-            <<< Test scripts to run >>>
           OUTPUT
                                           ).to_stdout
         end
@@ -87,7 +46,7 @@ RSpec.describe CobraCommander::CLI::Output::Change do
 
       context "with a change inside a component" do
         it "lists change, affected component, and test" do
-          change = CobraCommander::CLI::Output::Change.new(umbrella, "full", "master",
+          change = CobraCommander::CLI::Output::Change.new(umbrella, "master",
                                                            changes: [umbrella.path.join("hr", "index.html")])
 
           expect { change.run! }.to output(<<~OUTPUT
@@ -98,9 +57,6 @@ RSpec.describe CobraCommander::CLI::Output::Change do
             hr - Stub
 
             <<< Transitively affected components >>>
-
-            <<< Test scripts to run >>>
-            #{umbrella.path.join('hr', 'test.sh')}
           OUTPUT
                                           ).to_stdout
         end
@@ -109,7 +65,7 @@ RSpec.describe CobraCommander::CLI::Output::Change do
       context "with changes inside multiple components" do
         it "lists changes, affected components, and tests" do
           change = CobraCommander::CLI::Output::Change.new(
-            umbrella, "full", "master",
+            umbrella, "master",
             changes: [umbrella.path.join("directory", "index.js"), umbrella.path.join("sales", "index.js")]
           )
 
@@ -126,12 +82,6 @@ RSpec.describe CobraCommander::CLI::Output::Change do
             finance - Stub
             hr - Stub
             sales - Stub
-
-            <<< Test scripts to run >>>
-            #{umbrella.path.join('directory', 'test.sh')}
-            #{umbrella.path.join('finance', 'test.sh')}
-            #{umbrella.path.join('hr', 'test.sh')}
-            #{umbrella.path.join('sales', 'test.sh')}
           OUTPUT
                                           ).to_stdout
         end
@@ -139,7 +89,7 @@ RSpec.describe CobraCommander::CLI::Output::Change do
 
       context "with change inside a very utilized component" do
         it "lists changes, affected components, and tests" do
-          change = CobraCommander::CLI::Output::Change.new(umbrella, "full", "master",
+          change = CobraCommander::CLI::Output::Change.new(umbrella, "master",
                                                            changes: [umbrella.path.join("auth", "index.html")])
 
           expect { change.run! }.to output(<<~OUTPUT
@@ -154,13 +104,6 @@ RSpec.describe CobraCommander::CLI::Output::Change do
             finance - Stub
             hr - Stub
             sales - Stub
-
-            <<< Test scripts to run >>>
-            #{umbrella.path.join('auth', 'test.sh')}
-            #{umbrella.path.join('directory', 'test.sh')}
-            #{umbrella.path.join('finance', 'test.sh')}
-            #{umbrella.path.join('hr', 'test.sh')}
-            #{umbrella.path.join('sales', 'test.sh')}
           OUTPUT
                                           ).to_stdout
         end

--- a/cobra_commander/spec/cobra_commander/cli_spec.rb
+++ b/cobra_commander/spec/cobra_commander/cli_spec.rb
@@ -253,40 +253,22 @@ RSpec.describe "cobra cli", type: :aruba do
   describe "cobra changes" do
     let(:umbrella) { stub_umbrella("modified-app", unpack: true) }
 
-    it "does not output 'Test scripts to run' header" do
-      run_command_and_stop("cobra changes -a #{umbrella.path} -b main", fail_on_error: false)
-
-      expect(last_command_output).to_not include("Test scripts to run")
-      expect(last_command_output).to include("modified-app/finance/test.sh")
-      expect(last_command_output).to include("modified-app/sales/test.sh")
-    end
-
     context "with full results" do
       it "outputs all headers" do
-        run_command_and_stop("cobra changes -a #{umbrella.path} -r full -b main", fail_on_error: true)
+        run_command_and_stop("cobra changes -a #{umbrella.path} -b main", fail_on_error: true)
 
         expect(last_command_output).to include("Changes since last commit on main")
         expect(last_command_output).to include("Directly affected components")
         expect(last_command_output).to include("Transitively affected components")
-        expect(last_command_output).to include("Test scripts to run")
-      end
-    end
-
-    context "with incorrect results specified" do
-      it "outputs error message" do
-        run_command_and_stop("cobra changes -a #{umbrella.path} -b main -r partial", fail_on_error: false)
-
-        expect(last_command_output).to match "--results must be 'test', 'full', 'name' or 'json'"
       end
     end
 
     context "with nonexistent branch specified" do
       it "outputs specified branch in 'Changes since' header" do
-        run_command_and_stop("cobra changes -a #{umbrella.path} -r full -b oak_branch", fail_on_error: true)
+        run_command_and_stop("cobra changes -a #{umbrella.path} -b oak_branch", fail_on_error: false)
 
         expect(last_command_output).to include("Changes since last commit on oak_branch")
         expect(last_command_output).to include("Specified branch oak_branch could not be found")
-        expect(last_command_output).to_not include("Test scripts to run")
       end
     end
   end


### PR DESCRIPTION
Cleanup `cobra changes`, removing unused/invalid information about test scripts and the JSON format.

- Remove unused output and formats from cobra change
- Remove unused information from Cobra::Affected
