### PR TITLE
Drop direct dependency to contracts

### DIFF
--- a/cobra_commander/Gemfile
+++ b/cobra_commander/Gemfile
@@ -7,5 +7,3 @@ gemspec
 group :cobra do
   gem "cobra_commander-stub", path: "./spec/support/", require: "stub_source"
 end
-
-gem "contracts", "< 0.17"

--- a/cobra_commander/Gemfile.lock
+++ b/cobra_commander/Gemfile.lock
@@ -192,7 +192,6 @@ DEPENDENCIES
   bundler
   cobra_commander!
   cobra_commander-stub!
-  contracts (< 0.17)
   guard-rspec
   license_finder (>= 7.0)
   pry


### PR DESCRIPTION
This direct dependency was added to hold the upgrade of contracts. This is no longer necessary as the gem who introduced this dependency have already changed their dep definition.