### PR TITLE
Allow plugins to enhance command execution

### DIFF
--- a/cobra_commander-ruby/Gemfile.lock
+++ b/cobra_commander-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cobra_commander (1.1.0)
+    cobra_commander (1.2.0)
       bundler (>= 2.4.17)
       thor (>= 0.18.1, < 2.0)
       tty-command (~> 0.10.0)
@@ -10,7 +10,7 @@ PATH
 PATH
   remote: .
   specs:
-    cobra_commander-ruby (1.0.0)
+    cobra_commander-ruby (1.1.0)
       bundler (>= 2.4.17)
 
 GEM

--- a/cobra_commander-ruby/docs/CHANGELOG.md
+++ b/cobra_commander-ruby/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Enhance command execution from the ruby source via `Bundle#around_command`: it wraps the run in `Bundler.with_unbundled_env` and yields `BUNDLE_APP_CONFIG` pointing at the umbrella's `.bundle` directory, so nested `bundle` calls resolve their config from the umbrella. Only the ruby plugin applies this isolation.
 * Raise the minimum supported Ruby version to 3.2 and expand CI to cover Ruby 4.0.
 
 ## Version 1.0.0 - 2022-10-15

--- a/cobra_commander-ruby/docs/CHANGELOG.md
+++ b/cobra_commander-ruby/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## Version 1.1.0 - 2026-06-09
 
 * Enhance command execution from the ruby source via `Bundle#around_command`: it wraps the run in `Bundler.with_unbundled_env` and yields `BUNDLE_APP_CONFIG` pointing at the umbrella's `.bundle` directory, so nested `bundle` calls resolve their config from the umbrella. Only the ruby plugin applies this isolation.
 * Raise the minimum supported Ruby version to 3.2 and expand CI to cover Ruby 4.0.

--- a/cobra_commander-ruby/lib/cobra_commander/ruby/bundle.rb
+++ b/cobra_commander-ruby/lib/cobra_commander/ruby/bundle.rb
@@ -19,6 +19,17 @@ module CobraCommander
         end
       end
 
+      # Runs the command with the ambient Bundler environment stripped, so a
+      # nested `bundle` call resolves the package's own bundle rather than
+      # cobra's, and points BUNDLE_APP_CONFIG at the umbrella's .bundle
+      # directory so that bundle config is read from the umbrella. Only the
+      # ruby plugin isolates the bundle this way.
+      def around_command
+        ::Bundler.with_unbundled_env do
+          yield({ "BUNDLE_APP_CONFIG" => path.join(".bundle").to_s })
+        end
+      end
+
     private
 
       def lockfile

--- a/cobra_commander-ruby/lib/cobra_commander/ruby/version.rb
+++ b/cobra_commander-ruby/lib/cobra_commander/ruby/version.rb
@@ -2,6 +2,6 @@
 
 module CobraCommander
   module Ruby
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end

--- a/cobra_commander-ruby/spec/cobra_commander/ruby/bundle_spec.rb
+++ b/cobra_commander-ruby/spec/cobra_commander/ruby/bundle_spec.rb
@@ -29,4 +29,27 @@ RSpec.describe CobraCommander::Ruby::Bundle do
   it "package paths are the root path of a package" do
     expect(hr_package.path.to_s).to eql "#{dummy_path}/components/hr"
   end
+
+  describe "#around_command" do
+    it "yields BUNDLE_APP_CONFIG pointing at the umbrella .bundle directory" do
+      yielded = nil
+
+      subject.around_command { |env| yielded = env }
+
+      expect(yielded).to eql("BUNDLE_APP_CONFIG" => "#{dummy_path}/.bundle")
+    end
+
+    it "runs the block with the ambient Bundler environment stripped" do
+      Bundler::ORIGINAL_ENV["BUNDLE_GEMFILE"] = "Funny"
+      captured = "unset"
+
+      subject.around_command { |_env| captured = ENV.fetch("BUNDLE_GEMFILE", nil) }
+
+      expect(captured).to be_nil
+    end
+
+    it "returns the value of the block" do
+      expect(subject.around_command { |_env| :result }).to eql(:result)
+    end
+  end
 end

--- a/cobra_commander-yarn/Gemfile.lock
+++ b/cobra_commander-yarn/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cobra_commander (1.1.0)
+    cobra_commander (1.2.0)
       bundler (>= 2.4.17)
       thor (>= 0.18.1, < 2.0)
       tty-command (~> 0.10.0)

--- a/cobra_commander/Gemfile.lock
+++ b/cobra_commander/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cobra_commander (1.1.0)
+    cobra_commander (1.2.0)
       bundler (>= 2.4.17)
       thor (>= 0.18.1, < 2.0)
       tty-command (~> 0.10.0)

--- a/cobra_commander/docs/CHANGELOG.md
+++ b/cobra_commander/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Add an `around_command` extension point so plugins can enhance the shell used to run `cmd`/`exec`. `Source#around_command` wraps execution (e.g. Bundler isolation) and yields a hash of environment variables for the command (base yields `{}`, scoped per-execution via TTY). Packages delegate to their source; `Component#around_command` nests each distinct source's wrapper and yields their merged env. `exec` applies it once per component (all packages contribute, later sources win); `cmd` applies each package's own. `IsolatedPTY` is now a plain PTY command — isolation comes from the sources.
 * Raise the minimum supported Ruby version to 3.2 and expand CI to cover Ruby 4.0.
 
 ## Version 1.1.0 - 2023-03-09

--- a/cobra_commander/docs/CHANGELOG.md
+++ b/cobra_commander/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## Version 1.2.0 - 2026-06-09
 
 * Add an `around_command` extension point so plugins can enhance the shell used to run `cmd`/`exec`. `Source#around_command` wraps execution (e.g. Bundler isolation) and yields a hash of environment variables for the command (base yields `{}`, scoped per-execution via TTY). Packages delegate to their source; `Component#around_command` nests each distinct source's wrapper and yields their merged env. `exec` applies it once per component (all packages contribute, later sources win); `cmd` applies each package's own. `IsolatedPTY` is now a plain PTY command — isolation comes from the sources.
 * Raise the minimum supported Ruby version to 3.2 and expand CI to cover Ruby 4.0.

--- a/cobra_commander/lib/cobra_commander/component.rb
+++ b/cobra_commander/lib/cobra_commander/component.rb
@@ -33,8 +33,8 @@ module CobraCommander
     #
     # @yieldparam env [Hash{String => String}] merged env vars for the command
     # @return the value returned by the block
-    def around_command(&block)
-      nest_sources(@packages.map(&:source).uniq, {}, &block)
+    def around_command(&)
+      nest_sources(@packages.map(&:source).uniq, {}, &)
     end
 
     def inspect
@@ -68,7 +68,7 @@ module CobraCommander
     # Nests each source's #around_command, accumulating the env each yields,
     # and finally yields the merged env to the block.
     def nest_sources(sources, env, &block)
-      return block.call(env) if sources.empty?
+      return yield(env) if sources.empty?
 
       head, *rest = sources
       head.around_command do |source_env|

--- a/cobra_commander/lib/cobra_commander/component.rb
+++ b/cobra_commander/lib/cobra_commander/component.rb
@@ -25,6 +25,18 @@ module CobraCommander
       @packages.map(&:path).uniq
     end
 
+    # Wraps the execution of a command on this component by nesting the
+    # around_command of each distinct source backing its packages, so every
+    # package gets a chance to enhance the surrounding process. The env vars
+    # each source yields are merged (later sources win) and the merged hash is
+    # yielded to the block.
+    #
+    # @yieldparam env [Hash{String => String}] merged env vars for the command
+    # @return the value returned by the block
+    def around_command(&block)
+      nest_sources(@packages.map(&:source).uniq, {}, &block)
+    end
+
     def inspect
       "#<CobraCommander::Component:#{object_id} #{name} dependencies=#{dependencies.map(&:name)} packages=#{packages}>"
     end
@@ -49,6 +61,19 @@ module CobraCommander
 
     def dependencies
       @dependencies ||= @dependency_names.sort.filter_map { |name| @umbrella.find(name) }
+    end
+
+  private
+
+    # Nests each source's #around_command, accumulating the env each yields,
+    # and finally yields the merged env to the block.
+    def nest_sources(sources, env, &block)
+      return block.call(env) if sources.empty?
+
+      head, *rest = sources
+      head.around_command do |source_env|
+        nest_sources(rest, env.merge(source_env), &block)
+      end
     end
   end
 end

--- a/cobra_commander/lib/cobra_commander/executor/command.rb
+++ b/cobra_commander/lib/cobra_commander/executor/command.rb
@@ -21,29 +21,31 @@ module CobraCommander
       # @param package [CobraComander::Package] target package to execute the named command
       # @return [Array<Symbol, String>]
       def call(tty, package)
-        run_command tty, package, @command_name
+        package.around_command do |env|
+          run_command tty, package, @command_name, env
+        end
       end
 
     private
 
-      def run_command(tty, package, command_name)
+      def run_command(tty, package, command_name, env)
         definition = package.source.config&.dig("commands", command_name)
         case definition
-        when Array then run_multiple(tty, package, definition)
-        when Hash then run_with_criteria(tty, package, definition)
+        when Array then run_multiple(tty, package, definition, env)
+        when Hash then run_with_criteria(tty, package, definition, env)
         when nil then [:skip, format(SKIP_UNEXISTING, command_name, package.key)]
-        else run_script(tty, definition, package.path)
+        else run_script(tty, definition, package.path, env: env)
         end
       end
 
-      def run_with_criteria(tty, package, command)
+      def run_with_criteria(tty, package, command, env)
         return [:skip, format(SKIP_CRITERIA, package.name)] unless match_criteria?(package, command.fetch("if", {}))
 
-        run_script(tty, command["run"], package.path)
+        run_script(tty, command["run"], package.path, env: env)
       end
 
-      def run_multiple(tty, package, commands)
-        run_many(commands) { run_command(tty, package, _1) }
+      def run_multiple(tty, package, commands, env)
+        run_many(commands) { run_command(tty, package, _1, env) }
       end
     end
   end

--- a/cobra_commander/lib/cobra_commander/executor/isolated_pty.rb
+++ b/cobra_commander/lib/cobra_commander/executor/isolated_pty.rb
@@ -3,26 +3,17 @@
 module CobraCommander
   module Executor
     #
-    # Executes commands in a clean environment, without the influence
-    # of the current Bundler env vars.
+    # A PTY-enabled TTY::Command used to execute component scripts.
+    #
+    # Per-execution environment variables are supplied to TTY::Command#run!
+    # (so they are scoped to each subprocess and never mutate the parent
+    # ENV), while environment isolation/enhancement such as Bundler's
+    # `with_unbundled_env` is contributed by the package sources through
+    # their #around_command (see CobraCommander::Ruby::Bundle).
     #
     class IsolatedPTY < ::TTY::Command
       def initialize(**)
         super(pty: true, **)
-      end
-
-      def run!(...)
-        isolate_bundle do
-          super(...)
-        end
-      end
-
-      def isolate_bundle(&)
-        if Bundler.respond_to?(:with_unbundled_env)
-          Bundler.with_unbundled_env(&)
-        else
-          Bundler.with_clean_env(&)
-        end
       end
     end
   end

--- a/cobra_commander/lib/cobra_commander/executor/run_script.rb
+++ b/cobra_commander/lib/cobra_commander/executor/run_script.rb
@@ -3,8 +3,8 @@
 module CobraCommander
   module Executor
     module RunScript
-      def run_script(tty, script, path)
-        result = tty.run!(script, chdir: path, err: :out)
+      def run_script(tty, script, path, env: {})
+        result = tty.run!(env, script, chdir: path, err: :out)
 
         return [:error, result.out] if result.failed?
 

--- a/cobra_commander/lib/cobra_commander/executor/script.rb
+++ b/cobra_commander/lib/cobra_commander/executor/script.rb
@@ -22,7 +22,9 @@ module CobraCommander
       # @param component [CobraComander::Component] target component
       # @return [Array<Symbol, String>]
       def call(tty, component)
-        run_many(component.root_paths) { run_script(tty, @script, _1) }
+        component.around_command do |env|
+          run_many(component.root_paths) { run_script(tty, @script, _1, env: env) }
+        end
       end
     end
   end

--- a/cobra_commander/lib/cobra_commander/package.rb
+++ b/cobra_commander/lib/cobra_commander/package.rb
@@ -9,17 +9,13 @@ module CobraCommander
 
     attr_reader :source, :path, :name, :dependencies
 
-    def_delegators :source, :key
+    def_delegators :source, :key, :around_command
 
     def initialize(source, path:, dependencies:, name:)
       @source = source
       @path = path
       @name = name
       @dependencies = dependencies
-    end
-
-    def around_command(&)
-      source.around_command(&)
     end
 
     def describe

--- a/cobra_commander/lib/cobra_commander/package.rb
+++ b/cobra_commander/lib/cobra_commander/package.rb
@@ -18,6 +18,10 @@ module CobraCommander
       @dependencies = dependencies
     end
 
+    def around_command(&)
+      source.around_command(&)
+    end
+
     def describe
       "#{name} (#{key})"
     end

--- a/cobra_commander/lib/cobra_commander/source.rb
+++ b/cobra_commander/lib/cobra_commander/source.rb
@@ -22,6 +22,17 @@ module CobraCommander
       to_a
     end
 
+    # Wraps the execution of commands on this source's packages, letting the
+    # source enhance the surrounding process (e.g. Bundler isolation) and
+    # contribute environment variables to the command. The base implementation
+    # yields an empty env; plugins override it (see CobraCommander::Ruby::Bundle).
+    #
+    # @yieldparam env [Hash{String => String}] env vars to pass to the command
+    # @return the value returned by the block
+    def around_command
+      yield({})
+    end
+
     def each(&)
       packages.each(&)
     rescue Errno::ENOENT => e

--- a/cobra_commander/lib/cobra_commander/version.rb
+++ b/cobra_commander/lib/cobra_commander/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CobraCommander
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/cobra_commander/spec/cobra_commander/component_spec.rb
+++ b/cobra_commander/spec/cobra_commander/component_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CobraCommander::Component do
+  let(:umbrella) { double("umbrella") }
+  subject(:component) { described_class.new(umbrella, "finance") }
+
+  describe "#around_command" do
+    def package_from(name, source)
+      CobraCommander::Package.new(source, name: name, path: "./", dependencies: [])
+    end
+
+    # A source double whose #around_command yields the given env (like a real
+    # source) and records its invocation order.
+    def source_yielding(key, env, order: nil, marker: nil)
+      double(key.to_s, key: key).tap do |source|
+        allow(source).to receive(:around_command) do |&block|
+          order << marker if order
+          block.call(env)
+        end
+      end
+    end
+
+    it "yields an empty env when no package contributes one" do
+      component.add_package(package_from("a", source_yielding(:a, {})))
+
+      yielded = nil
+      result = component.around_command { |env| yielded = env and :ran }
+
+      expect(yielded).to eql({})
+      expect(result).to eql(:ran)
+    end
+
+    it "yields the merged env of each distinct source" do
+      component.add_package(package_from("a", source_yielding(:a, { "A" => "1" })))
+      component.add_package(package_from("b", source_yielding(:b, { "B" => "2" })))
+
+      yielded = nil
+      component.around_command { |env| yielded = env }
+
+      expect(yielded).to eql("A" => "1", "B" => "2")
+    end
+
+    it "lets later sources win on key collisions" do
+      component.add_package(package_from("a", source_yielding(:a, { "A" => "1" })))
+      component.add_package(package_from("b", source_yielding(:b, { "A" => "2" })))
+
+      yielded = nil
+      component.around_command { |env| yielded = env }
+
+      expect(yielded).to eql("A" => "2")
+    end
+
+    it "nests each source's around_command around the block" do
+      order = []
+      component.add_package(package_from("a", source_yielding(:a, {}, order: order, marker: :s1)))
+      component.add_package(package_from("b", source_yielding(:b, {}, order: order, marker: :s2)))
+
+      component.around_command { order << :inner }
+
+      expect(order).to eq(%i[s1 s2 inner])
+    end
+
+    it "invokes a shared source's around_command only once" do
+      source = source_yielding(:a, {})
+      component.add_package(package_from("a", source))
+      component.add_package(package_from("b", source))
+
+      component.around_command { |_env| :ran }
+
+      expect(source).to have_received(:around_command).once
+    end
+  end
+end

--- a/cobra_commander/spec/cobra_commander/executor/command_spec.rb
+++ b/cobra_commander/spec/cobra_commander/executor/command_spec.rb
@@ -101,18 +101,18 @@ RSpec.describe CobraCommander::Executor::Command do
     let(:source) do
       stub_source("le source", key: "le",
                                config: {
-                            "commands" => {
-                              "skp" => will_skip,
-                              "fail" => failing_command,
-                              "rofl" => command_rofl,
-                              "lol" => command_lol,
-                              "lol_and_fail" => %w[lol fail rofl],
-                              "ltc" => %w[lol rofl],
-                              "ltc_lol" => %w[ltc lol],
-                              "lol_skip_rolf" => %w[lol skp rofl],
-                              "lol_skip" => %w[lol skp],
-                            },
-                          })
+                                 "commands" => {
+                                   "skp" => will_skip,
+                                   "fail" => failing_command,
+                                   "rofl" => command_rofl,
+                                   "lol" => command_lol,
+                                   "lol_and_fail" => %w[lol fail rofl],
+                                   "ltc" => %w[lol rofl],
+                                   "ltc_lol" => %w[ltc lol],
+                                   "lol_skip_rolf" => %w[lol skp rofl],
+                                   "lol_skip" => %w[lol skp],
+                                 },
+                               })
     end
     let(:package) { CobraCommander::Package.new(source, path: "./", dependencies: [], name: "management") }
 

--- a/cobra_commander/spec/cobra_commander/executor/command_spec.rb
+++ b/cobra_commander/spec/cobra_commander/executor/command_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe CobraCommander::Executor::Command do
     CobraCommander::Executor::Command.new(command).call(pty, package)
   end
 
+  # A source double that, like a real Source, yields the given env from
+  # #around_command (the base Source yields {}).
+  def stub_source(name, env: {}, **stubs)
+    double(name, **stubs).tap do |source|
+      allow(source).to receive(:around_command) { |&block| block.call(env) }
+    end
+  end
+
   it "executes the command configured in cobra.yml" do
     result, output = run_command(finance_stub_package, "deps")
 
@@ -27,6 +35,27 @@ RSpec.describe CobraCommander::Executor::Command do
                           "Check your cobra.yml for existing commands in stub."
   end
 
+  describe "package shell env" do
+    let(:source) do
+      stub_source("source", key: "le", env: { "COBRA_TEST" => "from-package" },
+                            config: { "commands" => { "show_env" => "echo $COBRA_TEST" } })
+    end
+    let(:package) { CobraCommander::Package.new(source, path: "./", dependencies: [], name: "management") }
+
+    it "passes the env yielded by the package's around_command to the command" do
+      result, output = run_command(package, "show_env")
+
+      expect(result).to be :success
+      expect(output).to include("from-package")
+    end
+
+    it "runs the command within the package's around_command" do
+      run_command(package, "show_env")
+
+      expect(source).to have_received(:around_command)
+    end
+  end
+
   describe "command criteria" do
     describe "depends_on" do
       let(:command) do
@@ -35,7 +64,7 @@ RSpec.describe CobraCommander::Executor::Command do
           "run" => "echo 'lol'",
         }
       end
-      let(:source) { double("le source", config: { "commands" => { "my_command" => command } }) }
+      let(:source) { stub_source("le source", config: { "commands" => { "my_command" => command } }) }
       let(:package_dependent) do
         CobraCommander::Package.new(source, path: "./", dependencies: %w[directory auth], name: "management")
       end
@@ -70,8 +99,8 @@ RSpec.describe CobraCommander::Executor::Command do
     let(:command_rofl) { "echo 'rofl'" }
     let(:command_lol) { "echo 'lol'" }
     let(:source) do
-      double("le source", key: "le",
-                          config: {
+      stub_source("le source", key: "le",
+                               config: {
                             "commands" => {
                               "skp" => will_skip,
                               "fail" => failing_command,

--- a/cobra_commander/spec/cobra_commander/executor/isolated_pty_spec.rb
+++ b/cobra_commander/spec/cobra_commander/executor/isolated_pty_spec.rb
@@ -4,15 +4,18 @@ require "spec_helper"
 require "cobra_commander/executor"
 
 RSpec.describe CobraCommander::Executor::IsolatedPTY do
-  it "executes the command in the given bundle context" do
-    Bundler::ORIGINAL_ENV["BUNDLE_GEMFILE"] = "Funny"
+  it "is a TTY::Command" do
+    expect(described_class.new(printer: :null)).to be_a(TTY::Command)
+  end
 
+  it "scopes a supplied env to the execution without leaking it into the parent" do
     output = StringIO.new
 
-    pty = CobraCommander::Executor::IsolatedPTY.new(printer: :quiet, output: output)
-    result = pty.run!("env", err: :out)
+    pty = described_class.new(printer: :quiet, output: output)
+    result = pty.run!({ "COBRA_TEST" => "scoped" }, "env", err: :out)
 
     expect(result).to be_success
-    expect(output.string).to_not match(/BUNDLE_GEMFILE/)
+    expect(output.string).to match(/COBRA_TEST=scoped/)
+    expect(ENV).to_not have_key("COBRA_TEST")
   end
 end

--- a/cobra_commander/spec/cobra_commander/executor/run_script_spec.rb
+++ b/cobra_commander/spec/cobra_commander/executor/run_script_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "cobra_commander/executor"
+
+RSpec.describe CobraCommander::Executor::RunScript do
+  let(:runner) do
+    Class.new do
+      include CobraCommander::Executor::RunScript
+    end.new
+  end
+  let(:tty) { TTY::Command.new(printer: :null) }
+
+  describe "#run_script" do
+    it "passes the given env to the executed shell" do
+      result, output = runner.run_script(tty, "echo $COBRA_TEST", Dir.pwd, env: { "COBRA_TEST" => "hello" })
+
+      expect(result).to be :success
+      expect(output).to include("hello")
+    end
+
+    it "runs with an empty env by default" do
+      result, output = runner.run_script(tty, "echo ok", Dir.pwd)
+
+      expect(result).to be :success
+      expect(output).to include("ok")
+    end
+  end
+end

--- a/cobra_commander/spec/cobra_commander/executor/script_spec.rb
+++ b/cobra_commander/spec/cobra_commander/executor/script_spec.rb
@@ -19,17 +19,41 @@ RSpec.describe CobraCommander::Executor::Script do
     expect(output).to include("I am at #{finance_package.path}")
   end
 
-  it "cleans BUNDLE environment so a nested bundle call can succeed" do
-    result, output = run_script(finance_component, "bundle exec env")
-
-    expect(result).to be :success
-    expect(output).to_not include("Install missing gem executables with")
-  end
-
   it "fails when the script fails" do
     result, output = run_script(finance_component, "lol_I_clearly_dont_exist_as_a_command_please")
 
     expect(result).to be :error
     expect(output).to match(/lol_I_clearly_dont_exist_as_a_command_please.*not found/)
+  end
+
+  it "passes the env yielded by the component's around_command to the script" do
+    component = component_with(env: { "COBRA_TEST" => "from-component" })
+
+    result, output = run_script(component, "echo $COBRA_TEST")
+
+    expect(result).to be :success
+    expect(output).to include("from-component")
+  end
+
+  it "wraps execution in the component's around_command" do
+    source = source_yielding({})
+    component = component_with(source: source)
+
+    run_script(component, "echo hi")
+
+    expect(source).to have_received(:around_command)
+  end
+
+  def source_yielding(env)
+    double("source", key: :ruby).tap do |s|
+      allow(s).to receive(:around_command) { |&block| block.call(env) }
+    end
+  end
+
+  def component_with(env: {}, source: nil)
+    source ||= source_yielding(env)
+    CobraCommander::Component.new(double("umbrella"), "finance").tap do |c|
+      c.add_package(CobraCommander::Package.new(source, name: "finance", path: Dir.pwd, dependencies: []))
+    end
   end
 end

--- a/cobra_commander/spec/cobra_commander/package_spec.rb
+++ b/cobra_commander/spec/cobra_commander/package_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CobraCommander::Package do
+  let(:source) { double("source", key: :ruby) }
+
+  subject(:package) do
+    CobraCommander::Package.new(source, name: "auth", path: "./", dependencies: [])
+  end
+
+  describe "#around_command" do
+    it "delegates to its source, forwarding the block" do
+      expect(source).to receive(:around_command) { |&block| block.call({ "FOO" => "bar" }) }
+
+      yielded = nil
+      package.around_command { |env| yielded = env }
+
+      expect(yielded).to eql("FOO" => "bar")
+    end
+  end
+end

--- a/cobra_commander/spec/cobra_commander/source_spec.rb
+++ b/cobra_commander/spec/cobra_commander/source_spec.rb
@@ -35,4 +35,16 @@ RSpec.describe CobraCommander::Source do
       expect(memory_source.config).to eql "memory config"
     end
   end
+
+  describe "#around_command" do
+    it "yields an empty env and returns the block's value by default" do
+      memory_source, = CobraCommander::Source.load("doesnt_matter", memory: true)
+      yielded = nil
+
+      result = memory_source.around_command { |env| yielded = env and :result }
+
+      expect(yielded).to eql({})
+      expect(result).to eql(:result)
+    end
+  end
 end


### PR DESCRIPTION
**Summary**

Components can be composed of packages from multiple sources. When running `cmd`/`exec`, each package now gets a chance to enhance the shell used for execution. Sources expose a single `around_command` hook that both wraps the run and yields environment variables for the command. The first use: the ruby plugin isolates the ambient Bundler env and points `BUNDLE_APP_CONFIG` at the umbrella's `.bundle` directory.

- Extensible: any plugin can enhance execution (env + wrapping) through one hook, without touching the executor core.
- Bundler isolation is now opt-in per source — only the ruby plugin applies `with_unbundled_env`, instead of it being hardcoded for every execution.
- Env vars are scoped to each subprocess via TTY and never mutate the parent `ENV`.
- Nested `bundle` calls in ruby components resolve their config from the umbrella via `BUNDLE_APP_CONFIG`.

**Changes**

1. Add `Source#around_command` — wraps execution and yields a hash of env vars (base yields `{}`). `Package` delegates to its source.
2. `Component#around_command` nests each distinct source's `around_command` and yields their merged env (later sources win).
3. `RunScript#run_script` takes an `env:` keyword and passes it to `TTY::Command` as the per-execution env hash.
4. `cmd` runs inside the package's `around_command`; `exec` runs inside the component's merged `around_command`. `exec` runs once per component while every package contributes.
5. `cobra_commander-ruby`: `Bundle#around_command` wraps the run in `Bundler.with_unbundled_env` and yields `BUNDLE_APP_CONFIG => <umbrella>/.bundle`.
